### PR TITLE
[Bug Fix] Workaround libev bug.

### DIFF
--- a/swarm/urlfetcher/ev_event_loop.hpp
+++ b/swarm/urlfetcher/ev_event_loop.hpp
@@ -29,6 +29,14 @@
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 
+//!@note: This is workaround libev bug
+//!       http://stackoverflow.com/questions/16660816/libev-4-15-doesnt-compile-on-osx-10-8
+//!       On OSX EV_ERROR declared in `ev.h` conflicts with that declared
+//!       in `/usr/include/sys/event.h`.
+#if defined(__APPLE__) && defined(EV_ERROR)
+	#undef EV_ERROR
+#endif
+
 #define EV_MULTIPLICITY 1
 #include <ev++.h>
 


### PR DESCRIPTION
On OSX EV_ERROR declared in `ev.h` conflicts with that declared in `/usr/include/sys/event.h`.
http://stackoverflow.com/questions/16660816/libev-4-15-doesnt-compile-on-osx-10-8.
