### PR TITLE
send_reply(int code) method's behaviour restored.

### DIFF
--- a/thevoid/stream.hpp
+++ b/thevoid/stream.hpp
@@ -346,7 +346,11 @@ protected:
 	 */
 	void send_reply(int code)
 	{
-		reply()->send_error(static_cast<http_response::status_type>(code));
+		http_response response;
+		response.set_code(code);
+		response.headers().set_content_length(0);
+
+		send_reply(std::move(response));
 	}
 
 	/*!


### PR DESCRIPTION
Earlier send_error() method had been reworked according to its documentation (in the comment section).
These changes affected send_reply(int code) method's behaviour which called send_error().

Now send_reply(int code) manually constructs http_response and calls send_reply(http_response) method.

Previously send_reply(int code) method called send_error() method, which defers close() method call.

send_reply() methods should send response to the client and stop request processing as soon as possible.
This may be done by calling send_headers() and close() methods of the underlying reply stream.

close() method sets special flag 'm_close_invoked' that stops handler's methods invocation and defers close_impl() method call that actually closes connection with the client (or reuses the existing one to process next request).

Thus, send_reply() methods must not defer close() method call.

By now send_error() method is used internally when request handler is not yet constructed (headers parsing failed, invalid URL, missing handler) and close() method's call delay works fine.
