### PR TITLE
Build-deps: blackhole-dev (<< 0.3)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,8 @@ Priority: extra
 Maintainer: Ruslan Nigmatullin <euroelessar@yandex.ru>
 Build-Depends: cdbs, debhelper (>= 7), cmake, liburiparser-dev, libcurl4-openssl-dev, libxml2-dev,
   libev-dev, libboost-system-dev, libboost-regex-dev, libboost-thread-dev,
-  libboost-program-options-dev, libboost-filesystem-dev, libidn11-dev, blackhole-dev (>= 0.2.2-1)
+  libboost-program-options-dev, libboost-filesystem-dev, libidn11-dev,
+  blackhole-dev (>= 0.2.2-1), blackhole-dev (<< 0.3)
 Standards-Version: 3.9.3
 Section: libs
 Homepage: https://github.com/reverbrain/swarm


### PR DESCRIPTION
Swarm does not compile with the latest version of blackhole-dev: "error: blackhole/log.hpp: No such file or directory."

Swarm was written with second major version of blackhole-dev, so we need to add restriction to avoid compilation with the third one.
