### PR TITLE
Signal handling reworked.

### DIFF
--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -724,10 +724,10 @@ void connection<T>::process_data()
 			process_data();
 			// async_read is called by processed_data
 			return;
+		} else {
+			// need more data for request processing
+			async_read();
 		}
-
-		// need more data for request processing
-		async_read();
 	} else if (m_state & read_data) {
 		size_t data_from_body = std::min<size_t>(m_content_length, end - begin);
 		size_t processed_size = data_from_body;

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -739,6 +739,10 @@ void connection<T>::process_data()
 			}
 		}
 
+		if (processed_size > data_from_body) {
+			processed_size = data_from_body;
+		}
+
 		m_content_length -= processed_size;
 		m_access_received += processed_size;
 		m_unprocessed_begin = begin + processed_size;

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -104,6 +104,7 @@ public:
 	virtual void send_data(const boost::asio::const_buffer &buffer,
 		std::function<void (const boost::system::error_code &err)> &&handler) /*override*/;
 	void want_more();
+	void pause_receive();
 	virtual void initialize(base_request_stream_data *data);
 	virtual swarm::logger create_logger();
 	virtual void close(const boost::system::error_code &err) /*override*/;
@@ -209,6 +210,8 @@ private:
 	//! Uprocessed data
 	const char *m_unprocessed_begin;
 	const char *m_unprocessed_end;
+
+	bool m_pause_receive;
 };
 
 typedef connection<boost::asio::ip::tcp::socket> tcp_connection;

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -123,7 +123,7 @@ private:
 
 	//! Handle completion of a read operation.
 	void handle_read(const boost::system::error_code &err, std::size_t bytes_transferred);
-	void process_data(const char *begin, const char *end);
+	void process_data();
 
 	void async_read();
 

--- a/thevoid/server.cpp
+++ b/thevoid/server.cpp
@@ -50,9 +50,62 @@
 namespace ioremap {
 namespace thevoid {
 
-class server_data;
+namespace signal_handler {
 
-static std::weak_ptr<signal_handler> global_signal_set;
+std::mutex lock;
+std::set<base_server*> all_servers;
+
+static
+void stop(int signal_value)
+{
+	std::lock_guard<std::mutex> locker(lock);
+
+	for (auto it = all_servers.begin(); it != all_servers.end(); ++it) {
+		BH_LOG((*it)->logger(), SWARM_LOG_INFO, "Handled signal [%d], stop server", signal_value);
+		(*it)->stop();
+	}
+}
+
+static
+void reload(int signal_value)
+{
+	std::lock_guard<std::mutex> locker(lock);
+
+	for (auto it = all_servers.begin(); it != all_servers.end(); ++it) {
+		BH_LOG((*it)->logger(), SWARM_LOG_INFO, "Handled signal [%d], reload configuration", signal_value);
+		try {
+			(*it)->reload();
+		} catch (std::exception &e) {
+			BH_LOG((*it)->logger(), SWARM_LOG_ERROR, "Failed to reload configuration: %s", e.what());
+		}
+	}
+}
+
+static
+bool register_handler(void (*handler)(int), int signal_value)
+{
+	return ::signal(signal_value, handler) != SIG_ERR;
+}
+
+bool register_stop(int signal_value)
+{
+	return register_handler(stop, signal_value);
+}
+
+bool register_reload(int signal_value)
+{
+	return register_handler(reload, signal_value);
+}
+
+void add_server(base_server* server) {
+	all_servers.insert(server);
+}
+
+void remove_server(base_server* server) {
+	all_servers.erase(server);
+}
+
+} // namespace signal_handler
 
 server_data::server_data(base_server *server) :
 	logger(base_logger, blackhole::log::attributes_t()),
@@ -68,26 +121,15 @@ server_data::server_data(base_server *server) :
 	local_acceptors(new acceptors_list<unix_connection>(*this)),
 	tcp_acceptors(new acceptors_list<tcp_connection>(*this)),
 	monitor_acceptors(new acceptors_list<monitor_connection>(*this)),
-	signal_set(global_signal_set.lock()),
 	daemonize(false),
 	safe_mode(false),
 	options_parsed(false)
 {
 	swarm::utils::logger::init_attributes(base_logger);
-
-	if (!signal_set) {
-		signal_set = std::make_shared<signal_handler>();
-		global_signal_set = signal_set;
-	}
-
-	std::lock_guard<std::mutex> locker(signal_set->lock);
-	signal_set->all_servers.insert(this);
 }
 
 server_data::~server_data()
 {
-	std::lock_guard<std::mutex> locker(signal_set->lock);
-	signal_set->all_servers.erase(this);
 }
 
 void server_data::handle_stop()
@@ -108,45 +150,6 @@ boost::asio::io_service &server_data::get_worker_service()
 {
 	const uint id = (threads_round_robin++ % threads_count);
 	return *worker_io_services[id];
-}
-
-void signal_handler::stop_handler(int signal_value)
-{
-	if (auto signal_set = global_signal_set.lock()) {
-		std::lock_guard<std::mutex> locker(signal_set->lock);
-
-		for (auto it = signal_set->all_servers.begin(); it != signal_set->all_servers.end(); ++it) {
-			BH_LOG((*it)->logger, SWARM_LOG_INFO, "Handled signal [%d], stop server", signal_value);
-			(*it)->handle_stop();
-		}
-	}
-}
-
-void signal_handler::reload_handler(int signal_value)
-{
-	if (auto signal_set = global_signal_set.lock()) {
-		std::lock_guard<std::mutex> locker(signal_set->lock);
-
-		for (auto it = signal_set->all_servers.begin(); it != signal_set->all_servers.end(); ++it) {
-			BH_LOG((*it)->logger, SWARM_LOG_INFO, "Handled signal [%d], reload configuration", signal_value);
-			try {
-				(*it)->handle_reload();
-			} catch (std::exception &e) {
-				std::fprintf(stderr, "Failed to reload configuration: %s", e.what());
-			}
-		}
-	}
-}
-
-void signal_handler::ignore_handler(int signal_value)
-{
-	if (auto signal_set = global_signal_set.lock()) {
-		std::lock_guard<std::mutex> locker(signal_set->lock);
-
-		for (auto it = signal_set->all_servers.begin(); it != signal_set->all_servers.end(); ++it) {
-			BH_LOG((*it)->logger, SWARM_LOG_INFO, "Handled signal [%d], ignored", signal_value);
-		}
-	}
 }
 
 pid_file::pid_file(const std::string &path) : m_path(path), m_file(NULL)
@@ -218,6 +221,8 @@ base_server::~base_server()
 	m_data->worker_io_services.clear();
 	m_data->io_service.reset();
 	m_data->monitor_io_service.reset();
+
+	signal_handler::remove_server(this);
 }
 
 const swarm::logger &base_server::logger() const
@@ -583,11 +588,6 @@ int base_server::run()
 		return -9;
 	}
 
-	sigset_t previous_sigset;
-	sigset_t sigset;
-	sigfillset(&sigset);
-	pthread_sigmask(SIG_BLOCK, &sigset, &previous_sigset);
-
 	m_data->worker_works.emplace_back(new boost::asio::io_service::work(*m_data->monitor_io_service));
 	m_data->worker_works.emplace_back(new boost::asio::io_service::work(*m_data->io_service));
 
@@ -608,8 +608,6 @@ int base_server::run()
 	runner.service = m_data->io_service.get();
 	threads.emplace_back(new boost::thread(runner));
 
-	pthread_sigmask(SIG_SETMASK, &previous_sigset, NULL);
-
 	// Wait for all threads in the pool to exit.
 	for (std::size_t i = 0; i < threads.size(); ++i)
 		threads[i]->join();
@@ -627,6 +625,11 @@ int base_server::run()
 void base_server::stop()
 {
 	m_data->handle_stop();
+}
+
+void base_server::reload()
+{
+	m_data->handle_reload();
 }
 
 std::shared_ptr<base_stream_factory> base_server::factory(const http_request &request)

--- a/thevoid/server_p.hpp
+++ b/thevoid/server_p.hpp
@@ -21,7 +21,6 @@
 #include "acceptorlist_p.hpp"
 #include "connection_p.hpp"
 #include "monitor_connection_p.hpp"
-#include <signal.h>
 
 #include <mutex>
 #include <set>
@@ -34,38 +33,6 @@ namespace thevoid {
 
 //! This handler is created to resolve creation of several servers in one process,
 //! all of them must be stopped on SIGINT/SIGTERM signal
-class signal_handler
-{
-public:
-	signal_handler()
-	{
-		register_handler(stop_handler, SIGINT, "SIGINT");
-		register_handler(stop_handler, SIGTERM, "SIGTERM");
-		register_handler(stop_handler, SIGALRM, "SIGALRM");
-		register_handler(reload_handler, SIGHUP, "SIGHUP");
-		register_handler(ignore_handler, SIGUSR1, "SIGUSR1");
-		register_handler(ignore_handler, SIGUSR2, "SIGUSR2");
-	}
-
-	~signal_handler()
-	{
-	}
-
-	void register_handler(void (*handler)(int), int signal_value, const std::string &signal_name)
-	{
-		if (SIG_ERR == ::signal(signal_value, handler)) {
-			throw std::runtime_error("Cannot set up " + signal_name + " handler");
-		}
-	}
-
-	static void stop_handler(int);
-	static void reload_handler(int);
-	static void ignore_handler(int);
-
-	std::mutex lock;
-	std::set<server_data*> all_servers;
-};
-
 class pid_file
 {
 public:
@@ -121,8 +88,6 @@ public:
 	std::unique_ptr<acceptors_list<unix_connection>> local_acceptors;
 	std::unique_ptr<acceptors_list<tcp_connection>> tcp_acceptors;
 	std::unique_ptr<acceptors_list<monitor_connection>> monitor_acceptors;
-	//! The signal_set is used to register for process termination notifications.
-	std::shared_ptr<signal_handler> signal_set;
 	//! User handlers for urls
 	std::vector<std::pair<base_server::options, factory_ptr>> handlers;
 	//! User id change to during deamonization

--- a/thevoid/stream.hpp
+++ b/thevoid/stream.hpp
@@ -268,12 +268,6 @@ protected:
 		return m_reply;
 	}
 
-	__attribute__((deprecated))
-	const std::shared_ptr<reply_stream> &get_reply()
-	{
-		return reply();
-	}
-
 private:
 	blackhole::log::attributes_t *logger_attributes();
 

--- a/thevoid/stream.hpp
+++ b/thevoid/stream.hpp
@@ -130,6 +130,24 @@ public:
 	 */
 	virtual void want_more() = 0;
 	/*!
+	 * \brief Pauses processing data until want_more() method is called.
+	 *
+	 * This is method is not thread-safe and may be called from within
+	 * base_request_stream::on_headers() and base_request_stream::on_data() methods.
+	 *
+	 * If this method is called from within base_request_stream::on_headers() method
+	 * following base_request_stream::on_data() method's call is postponed until
+	 * want_more() method is called.
+	 *
+	 * Analogously, calling this method from within base_request_stream::on_data()
+	 * method will postpone following base_request_stream::on_data() or
+	 * base_request_stream::on_close() method's call.
+	 *
+	 * However, if error happens base_request_stream::on_close() with corresponding
+	 * error_code will be called.
+	 */
+	virtual void pause_receive() = 0;
+	/*!
 	 * \brief Closes socket to client.
 	 *
 	 * If \a err is set connection to client is terminated.

--- a/thevoid/stream.hpp
+++ b/thevoid/stream.hpp
@@ -551,6 +551,8 @@ private:
  *
  * After chunk's processing is finished call try_next_chunk.
  *
+ * One must call try_next_chunk() to receive first chunk.
+ *
  * \sa set_chunk_size
  */
 template <typename Server>
@@ -564,7 +566,7 @@ public:
 	};
 
 	buffered_request_stream() :
-		m_chunk_size(10 * 1024), m_client_asked_chunk(true),
+		m_chunk_size(10 * 1024), m_client_asked_chunk(false),
 		m_first_chunk(true), m_last_chunk(false),
 		m_unprocessed_size(0)
 	{


### PR DESCRIPTION
Merge #30 first.

All signal handling mechanics moved to thevoid::signal_handler namespace.

Added functions to add/remove server to/from global signal handling:
    thevoid::signal_handler::add_server(base_server\*)
    thevoid::signal_handler::remove_server(base_server\*)

Added functions to register stop/reload signals:
    thevoid::signal_handler::register_stop(int signal)
    thevoid::signal_handler::register_reload(int signal)