### PR TITLE
thevoid: library-wide signal handling mechanics reworked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(swarm)
 cmake_minimum_required(VERSION 2.6)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -W -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -W -Wall -Wextra -D_GLIBCXX_USE_NANOSLEEP")
 
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/debian/changelog" DEBCHANGELOG)
 

--- a/thevoid/server.cpp
+++ b/thevoid/server.cpp
@@ -629,6 +629,11 @@ void base_server::stop()
 	m_data->handle_stop();
 }
 
+void base_server::reload()
+{
+	m_data->handle_reload();
+}
+
 std::shared_ptr<base_stream_factory> base_server::factory(const http_request &request)
 {
 	for (auto it = m_data->handlers.begin(); it != m_data->handlers.end(); ++it) {

--- a/thevoid/server.hpp
+++ b/thevoid/server.hpp
@@ -50,6 +50,44 @@ class server_data;
 template <typename T> class connection;
 class monitor_connection;
 class server_options_private;
+class base_server;
+
+/*
+ * Library-wide signal handling mechanics.
+ */
+namespace signal_handler {
+
+/*!
+ * \brief Adds server to library-wide signal handling.
+ */
+void add_server(base_server* server);
+
+/*!
+ * \brief Removes server from library-wide signal handling.
+ */
+void remove_server(base_server* server);
+
+/*!
+ * \brief Registers stop/reload action on signal.
+ *
+ * Returns result of signal registration (was it successful or not).
+ */
+bool register_stop(int signal_value);
+bool register_reload(int signal_value);
+
+/*!
+ * \brief Start/stop library-wide signal handling.
+ *
+ * Signal handling mechanics uses separate thread for signal monitoring.
+ * On every signal registered with register_stop() method all added servers
+ * will be stopped.
+ * On every signal registered with register_reload() method all added servers
+ * will be requested to reload their configuration.
+ */
+void start();
+void stop();
+
+} // namespace signal_handler
 
 /*!
  * \brief The daemon_exception is thrown in case if daemonization fails.
@@ -397,7 +435,22 @@ std::shared_ptr<Server> create_server(Args &&...args)
 template <typename Server, typename... Args>
 int run_server(int argc, char **argv, Args &&...args)
 {
-	return create_server<Server>(std::forward<Args>(args)...)->run(argc, argv);
+	signal_handler::start();
+
+	signal_handler::register_stop(SIGINT);
+	signal_handler::register_stop(SIGTERM);
+	signal_handler::register_stop(SIGALRM);
+	signal_handler::register_reload(SIGHUP);
+
+	auto server = create_server<Server>(std::forward<Args>(args)...);
+	signal_handler::add_server(server.get());
+
+	int ret_code = server->run(argc, argv);
+
+	signal_handler::stop();
+	signal_handler::remove_server(server.get());
+
+	return ret_code;
 }
 
 } } // namespace ioremap::thevoid

--- a/thevoid/server.hpp
+++ b/thevoid/server.hpp
@@ -130,6 +130,11 @@ public:
 	void stop();
 
 	/*!
+	 * \brief Reload configuration
+	 */
+	void reload();
+
+	/*!
 	 * \brief Returns logger of the service.
 	 */
 	const swarm::logger &logger() const;

--- a/thevoid/server_p.hpp
+++ b/thevoid/server_p.hpp
@@ -21,7 +21,6 @@
 #include "acceptorlist_p.hpp"
 #include "connection_p.hpp"
 #include "monitor_connection_p.hpp"
-#include <signal.h>
 
 #include <mutex>
 #include <set>
@@ -34,38 +33,6 @@ namespace thevoid {
 
 //! This handler is created to resolve creation of several servers in one process,
 //! all of them must be stopped on SIGINT/SIGTERM signal
-class signal_handler
-{
-public:
-	signal_handler()
-	{
-		register_handler(stop_handler, SIGINT, "SIGINT");
-		register_handler(stop_handler, SIGTERM, "SIGTERM");
-		register_handler(stop_handler, SIGALRM, "SIGALRM");
-		register_handler(reload_handler, SIGHUP, "SIGHUP");
-		register_handler(ignore_handler, SIGUSR1, "SIGUSR1");
-		register_handler(ignore_handler, SIGUSR2, "SIGUSR2");
-	}
-
-	~signal_handler()
-	{
-	}
-
-	void register_handler(void (*handler)(int), int signal_value, const std::string &signal_name)
-	{
-		if (SIG_ERR == ::signal(signal_value, handler)) {
-			throw std::runtime_error("Cannot set up " + signal_name + " handler");
-		}
-	}
-
-	static void stop_handler(int);
-	static void reload_handler(int);
-	static void ignore_handler(int);
-
-	std::mutex lock;
-	std::set<server_data*> all_servers;
-};
-
 class pid_file
 {
 public:
@@ -121,8 +88,6 @@ public:
 	std::unique_ptr<acceptors_list<unix_connection>> local_acceptors;
 	std::unique_ptr<acceptors_list<tcp_connection>> tcp_acceptors;
 	std::unique_ptr<acceptors_list<monitor_connection>> monitor_acceptors;
-	//! The signal_set is used to register for process termination notifications.
-	std::shared_ptr<signal_handler> signal_set;
 	//! User handlers for urls
 	std::vector<std::pair<base_server::options, factory_ptr>> handlers;
 	//! User id change to during deamonization

--- a/thevoid/signal_handler.cpp
+++ b/thevoid/signal_handler.cpp
@@ -3,7 +3,7 @@
 #include <mutex>
 #include <set>
 #include <thread>
-#include <atomic>
+#include <blackhole/utils/atomic.hpp>
 
 #include <signal.h>
 #include <sys/prctl.h>

--- a/thevoid/signal_handler.cpp
+++ b/thevoid/signal_handler.cpp
@@ -1,0 +1,139 @@
+#include "server.hpp"
+
+#include <mutex>
+#include <set>
+#include <thread>
+#include <atomic>
+
+#include <signal.h>
+#include <sys/prctl.h>
+
+namespace ioremap { namespace thevoid { namespace signal_handler {
+
+namespace {
+
+// global mutex for all signal handling actions
+std::mutex lock;
+
+// library-wide monitoring servers
+std::set<base_server*> servers;
+
+// separate signal monitoring thread
+std::thread monitoring_thread;
+std::atomic<bool> running(false);
+
+// received stop/reload signals
+std::atomic<int> stop_request(-1);
+std::atomic<int> reload_request(-1);
+
+} // unnamed namespace
+
+void add_server(base_server* server) {
+	std::lock_guard<std::mutex> locker(lock);
+	servers.insert(server);
+}
+
+void remove_server(base_server* server) {
+	std::lock_guard<std::mutex> locker(lock);
+	servers.erase(server);
+}
+
+void stop_sa_handler(int sig) {
+	stop_request.store(sig);
+}
+
+void reload_sa_handler(int sig) {
+	reload_request.store(sig);
+}
+
+bool register_stop(int signal_value) {
+	std::lock_guard<std::mutex> locker(lock);
+
+	struct sigaction sa;
+	sa.sa_handler = stop_sa_handler;
+	int err = sigaction(signal_value, &sa, NULL);
+
+	return err == 0;
+}
+
+bool register_reload(int signal_value) {
+	std::lock_guard<std::mutex> locker(lock);
+
+	struct sigaction sa;
+	sa.sa_handler = reload_sa_handler;
+	int err = sigaction(signal_value, &sa, NULL);
+
+	return err == 0;
+}
+
+static
+void handle_stop(int signal_value) {
+	std::lock_guard<std::mutex> locker(lock);
+
+	for (auto it = servers.begin(); it != servers.end(); ++it) {
+		BH_LOG((*it)->logger(), SWARM_LOG_INFO, "Handled signal [%d], stop server", signal_value);
+		(*it)->stop();
+	}
+}
+
+static
+void handle_reload(int signal_value) {
+	std::lock_guard<std::mutex> locker(lock);
+
+	for (auto it = servers.begin(); it != servers.end(); ++it) {
+		BH_LOG((*it)->logger(), SWARM_LOG_INFO, "Handled signal [%d], reload configuration", signal_value);
+		try {
+			(*it)->reload();
+		} catch (std::exception &e) {
+			std::fprintf(stderr, "Failed to reload configuration: %s", e.what());
+		}
+	}
+}
+
+static
+void run() {
+	char thread_name[16];
+	memset(thread_name, 0, sizeof(thread_name));
+	sprintf(thread_name, "void_signal");
+	prctl(PR_SET_NAME, thread_name);
+
+	while (running) {
+		if (stop_request != -1) {
+			int signal_value = stop_request;
+
+			stop_request = -1;
+			reload_request = -1;
+
+			handle_stop(signal_value);
+		}
+		else if (reload_request != -1) {
+			int signal_value = reload_request;
+
+			reload_request = -1;
+
+			handle_reload(signal_value);
+		}
+		else {
+			std::this_thread::sleep_for(std::chrono::seconds(1));
+		}
+	}
+}
+
+void start() {
+	if (running) {
+		return;
+	}
+
+	running = true;
+	monitoring_thread = std::thread(run);
+}
+
+void stop() {
+	running = false;
+
+	if (monitoring_thread.joinable()) {
+		monitoring_thread.join();
+	}
+}
+
+}}} // namespace ioremap::thevoid::signal_handler


### PR DESCRIPTION
All signal handling mechanics moved to thevoid::signal_handler namespace.

[sigaction](http://man7.org/linux/man-pages/man2/sigaction.2.html) function is used to register handlers for specific signals. This function changes signal's disposition process-wide.
Registered signal handlers just set corresponding atomic flags which are monitored by separate thread ("void_signal").

Disadvantages of other approaches:
- signal:
  "The effects of [signal()](http://man7.org/linux/man-pages/man2/signal.2.html) in a multithreaded process are unspecified."
- signalfd:
  [signalfd()](http://man7.org/linux/man-pages/man2/signalfd.2.html) creates file descriptor that can be monitored for queued signals (blocked for the entire thread group). Thus, it's required to register (and block) all necessary signals from the main thread before creating any other threads. Otherwise, created threads may have these signals as not blocked and will receive them with default disposition.

Added functions to add/remove server to/from global signal handling:
thevoid::signal_handler::add_server(base_server\*)
thevoid::signal_handler::remove_server(base_server\*)

Pointers to all added servers are stored within global set and received signals affect all of them.
On server's destruction its pointer will be removed from the set, but it's still possible to remove server's pointer from the set if one doesn't want their server to react on specified signals.

Added functions to register stop/reload signals:
thevoid::signal_handler::register_stop(int signal)
thevoid::signal_handler::register_reload(int signal)

Added functions to start/stop library-wide signal handling mechanics:
thevoid::signal_handler::start()
thevoid::signal_handler::stop()

On start() separate thread ("void_signal") will be created and it'll run until stop() is called.