### PR TITLE
signal handling

### DIFF
--- a/example/server-config.json
+++ b/example/server-config.json
@@ -16,7 +16,8 @@
                 "sink": {
                     "type": "files",
                     "path": "/dev/stdout",
-                    "autoflush": true
+                    "autoflush": true,
+                    "rotation": { "move": 0 }
                 }
             }
         ]

--- a/example/server.cpp
+++ b/example/server.cpp
@@ -108,5 +108,11 @@ public:
 
 int main(int argc, char **argv)
 {
-	return ioremap::thevoid::run_server<http_server>(argc, argv);
+	// comment out the following piece of code to disable thevoid's signal handling
+	thevoid::register_stop_signal(SIGINT);
+	thevoid::register_stop_signal(SIGTERM);
+	thevoid::register_reload_signal(SIGHUP);
+
+	auto server = thevoid::create_server<http_server>();
+	return server->run(argc, argv);
 }

--- a/thevoid/server.cpp
+++ b/thevoid/server.cpp
@@ -44,15 +44,13 @@
 #include <blackhole/frontend/files.hpp>
 #include <blackhole/sink/socket.hpp>
 
+#include "signal_handler_p.hpp"
+
 #define UNIX_PREFIX "unix:"
 #define UNIX_PREFIX_LEN (sizeof(UNIX_PREFIX) / sizeof(char) - 1)
 
 namespace ioremap {
 namespace thevoid {
-
-class server_data;
-
-static std::weak_ptr<signal_handler> global_signal_set;
 
 server_data::server_data(base_server *server) :
 	logger(base_logger, blackhole::log::attributes_t()),
@@ -68,26 +66,15 @@ server_data::server_data(base_server *server) :
 	local_acceptors(new acceptors_list<unix_connection>(*this)),
 	tcp_acceptors(new acceptors_list<tcp_connection>(*this)),
 	monitor_acceptors(new acceptors_list<monitor_connection>(*this)),
-	signal_set(global_signal_set.lock()),
 	daemonize(false),
 	safe_mode(false),
 	options_parsed(false)
 {
 	swarm::utils::logger::init_attributes(base_logger);
-
-	if (!signal_set) {
-		signal_set = std::make_shared<signal_handler>();
-		global_signal_set = signal_set;
-	}
-
-	std::lock_guard<std::mutex> locker(signal_set->lock);
-	signal_set->all_servers.insert(this);
 }
 
 server_data::~server_data()
 {
-	std::lock_guard<std::mutex> locker(signal_set->lock);
-	signal_set->all_servers.erase(this);
 }
 
 void server_data::handle_stop()
@@ -108,45 +95,6 @@ boost::asio::io_service &server_data::get_worker_service()
 {
 	const uint id = (threads_round_robin++ % threads_count);
 	return *worker_io_services[id];
-}
-
-void signal_handler::stop_handler(int signal_value)
-{
-	if (auto signal_set = global_signal_set.lock()) {
-		std::lock_guard<std::mutex> locker(signal_set->lock);
-
-		for (auto it = signal_set->all_servers.begin(); it != signal_set->all_servers.end(); ++it) {
-			BH_LOG((*it)->logger, SWARM_LOG_INFO, "Handled signal [%d], stop server", signal_value);
-			(*it)->handle_stop();
-		}
-	}
-}
-
-void signal_handler::reload_handler(int signal_value)
-{
-	if (auto signal_set = global_signal_set.lock()) {
-		std::lock_guard<std::mutex> locker(signal_set->lock);
-
-		for (auto it = signal_set->all_servers.begin(); it != signal_set->all_servers.end(); ++it) {
-			BH_LOG((*it)->logger, SWARM_LOG_INFO, "Handled signal [%d], reload configuration", signal_value);
-			try {
-				(*it)->handle_reload();
-			} catch (std::exception &e) {
-				std::fprintf(stderr, "Failed to reload configuration: %s", e.what());
-			}
-		}
-	}
-}
-
-void signal_handler::ignore_handler(int signal_value)
-{
-	if (auto signal_set = global_signal_set.lock()) {
-		std::lock_guard<std::mutex> locker(signal_set->lock);
-
-		for (auto it = signal_set->all_servers.begin(); it != signal_set->all_servers.end(); ++it) {
-			BH_LOG((*it)->logger, SWARM_LOG_INFO, "Handled signal [%d], ignored", signal_value);
-		}
-	}
 }
 
 pid_file::pid_file(const std::string &path) : m_path(path), m_file(NULL)
@@ -583,11 +531,6 @@ int base_server::run()
 		return -9;
 	}
 
-	sigset_t previous_sigset;
-	sigset_t sigset;
-	sigfillset(&sigset);
-	pthread_sigmask(SIG_BLOCK, &sigset, &previous_sigset);
-
 	m_data->worker_works.emplace_back(new boost::asio::io_service::work(*m_data->monitor_io_service));
 	m_data->worker_works.emplace_back(new boost::asio::io_service::work(*m_data->io_service));
 
@@ -600,6 +543,10 @@ int base_server::run()
 		m_data->worker_threads.emplace_back(new boost::thread(runner));
 	}
 
+	// run signal handler in monitor io_service
+	signal_handler sighandler(this);
+	sighandler.run(m_data->monitor_io_service.get());
+
 	runner.name = "void_monitor";
 	runner.service = m_data->monitor_io_service.get();
 	threads.emplace_back(new boost::thread(runner));
@@ -607,8 +554,6 @@ int base_server::run()
 	runner.name = "void_acceptor";
 	runner.service = m_data->io_service.get();
 	threads.emplace_back(new boost::thread(runner));
-
-	pthread_sigmask(SIG_SETMASK, &previous_sigset, NULL);
 
 	// Wait for all threads in the pool to exit.
 	for (std::size_t i = 0; i < threads.size(); ++i)

--- a/thevoid/server.cpp
+++ b/thevoid/server.cpp
@@ -629,6 +629,11 @@ void base_server::stop()
 	m_data->handle_stop();
 }
 
+void base_server::reload()
+{
+	m_data->handle_reload();
+}
+
 std::shared_ptr<base_stream_factory> base_server::factory(const http_request &request)
 {
 	for (auto it = m_data->handlers.begin(); it != m_data->handlers.end(); ++it) {

--- a/thevoid/server.hpp
+++ b/thevoid/server.hpp
@@ -130,6 +130,11 @@ public:
 	void stop();
 
 	/*!
+	 * \brief Reload configuration
+	 */
+	void reload();
+
+	/*!
 	 * \brief Returns logger of the service.
 	 */
 	const swarm::logger &logger() const;

--- a/thevoid/signal_handler.cpp
+++ b/thevoid/signal_handler.cpp
@@ -1,0 +1,98 @@
+#include "signal_handler_p.hpp"
+
+#include <cstring>
+#include <functional>
+
+#include <signal.h>
+
+#include "server_p.hpp"
+
+namespace ioremap { namespace thevoid {
+
+static
+void stop_sa_handler(int sig) {
+	signal_handler::stop_request.store(sig);
+}
+
+static
+void reload_sa_handler(int sig) {
+	signal_handler::reload_request.store(sig);
+	signal_handler::reload_rev++;
+}
+
+bool register_stop_signal(int signal_value) {
+	struct sigaction sa;
+	std::memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = stop_sa_handler;
+	sigfillset(&sa.sa_mask);
+	int err = sigaction(signal_value, &sa, NULL);
+
+	return err == 0;
+}
+
+bool register_reload_signal(int signal_value) {
+	struct sigaction sa;
+	std::memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = reload_sa_handler;
+	sigfillset(&sa.sa_mask);
+	int err = sigaction(signal_value, &sa, NULL);
+
+	return err == 0;
+}
+
+std::atomic<int> signal_handler::stop_request(-1);
+
+std::atomic<int> signal_handler::reload_request(-1);
+std::atomic<size_t> signal_handler::reload_rev(0);
+
+signal_handler::signal_handler(
+		base_server* server,
+		const boost::posix_time::time_duration &timeout
+	)
+	: m_server(server)
+	, m_timeout(timeout)
+	, m_reload_signal_rev(0)
+{
+}
+
+void signal_handler::run(boost::asio::io_service* io_service) {
+	// init server's reload signal revision number with global one
+	m_reload_signal_rev = reload_rev;
+
+	m_timer = timer_ptr(new timer(*io_service));
+
+	m_timer->expires_from_now(m_timeout);
+	m_timer->async_wait(std::bind(&signal_handler::handle_timer, this, std::placeholders::_1));
+}
+
+void signal_handler::handle_timer(const boost::system::error_code &error)
+{
+	if (error != boost::asio::error::operation_aborted) {
+		// check stop_request first
+		if (stop_request != -1) {
+			int signal_value = stop_request;
+			BH_LOG(m_server->logger(), SWARM_LOG_INFO, "Handled signal [%d], stop server", signal_value);
+			m_server->stop();
+			return;
+		}
+
+		// check reload_request
+		if (reload_request != -1 && m_reload_signal_rev != reload_rev) {
+			m_reload_signal_rev = reload_rev;
+
+			int signal_value = reload_request;
+			BH_LOG(m_server->logger(), SWARM_LOG_INFO, "Handled signal [%d], reload configuration", signal_value);
+			try {
+				m_server->reload();
+			} catch (std::exception &e) {
+				std::fprintf(stderr, "Failed to reload configuration: %s", e.what());
+			}
+		}
+
+		// wait for next timeout
+		m_timer->expires_from_now(m_timeout);
+		m_timer->async_wait(std::bind(&signal_handler::handle_timer, this, std::placeholders::_1));
+	}
+}
+
+}} // namespace ioremap::thevoid

--- a/thevoid/signal_handler_p.hpp
+++ b/thevoid/signal_handler_p.hpp
@@ -1,0 +1,43 @@
+#ifndef IOREMAP_THEVOID_SIGNAL_HANDLER_P_HPP
+#define IOREMAP_THEVOID_SIGNAL_HANDLER_P_HPP
+
+#include <memory>
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <blackhole/utils/atomic.hpp>
+
+#include "server.hpp"
+
+namespace ioremap { namespace thevoid {
+
+struct signal_handler {
+	typedef boost::asio::deadline_timer timer;
+	typedef std::shared_ptr<timer> timer_ptr;
+
+	signal_handler(
+			base_server* server,
+			const boost::posix_time::time_duration &timeout = boost::posix_time::seconds(1)
+		);
+
+	void run(boost::asio::io_service* io_service);
+
+	void handle_timer(const boost::system::error_code &error);
+
+	// received stop signal
+	static std::atomic<int> stop_request;
+
+	// received reload signal and its global revision number
+	static std::atomic<int> reload_request;
+	static std::atomic<size_t> reload_rev;
+
+	base_server* m_server;
+	timer_ptr m_timer;
+	boost::posix_time::time_duration m_timeout;
+
+	size_t m_reload_signal_rev;
+};
+
+}} // namespace ioremap::thevoid
+
+#endif // IOREMAP_THEVOID_SIGNAL_HANDLER_P_HPP


### PR DESCRIPTION
This pull request solves the following problems:
- buggy signal handling implementation
- impossible to set custom set of signals for stop/reload actions
- impossible to disable thevoid's signal handling

Added functions to register stop/reload signals:
```(cpp)
thevoid::register_stop_signal(int signal)
thevoid::register_reload_signal(int signal)
```

If one registers no signals for stop and reload, then no signals will be blocked and handled by thevoid.

These functions use `sigaction()` to register handler for specific signal process-wide.

When registered stop signal will be catched all servers will be stopped (it works like "stop the world"). It's assumed that after receiving stop signal the whole process will terminate (thus, no server's restarting and so on) -- there's global "received stop signal" variable.

When registered reload signal will be catched all servers will be asked to reload their configuration (with dummy reload() method, this functionality will be added sometime).
Reload signal handling is a little bit tricky, because we need to continue working after receiving such signals (and continue receiving reload signals) -- there's global "received reload signal" and global "reload signal revision number" variables.
Each server somehow stores last handled reload signal's revision number, and if global "reload signal revision number" changes the server should handle global "received reload signal".

All this stuff (checking global variables, handling received signals) is performed within server's monitor io_service (thus, no separate thread) for each server.

Example server shows how one can register different set of signals for stop/reload actions (it differs from default one).