### PR TITLE
base_server::reload() public method added

### DIFF
--- a/example/server-config.json
+++ b/example/server-config.json
@@ -16,7 +16,8 @@
                 "sink": {
                     "type": "files",
                     "path": "/dev/stdout",
-                    "autoflush": true
+                    "autoflush": true,
+                    "rotation": { "move": 0 }
                 }
             }
         ]

--- a/thevoid/server.cpp
+++ b/thevoid/server.cpp
@@ -629,6 +629,11 @@ void base_server::stop()
 	m_data->handle_stop();
 }
 
+void base_server::reload()
+{
+	m_data->handle_reload();
+}
+
 std::shared_ptr<base_stream_factory> base_server::factory(const http_request &request)
 {
 	for (auto it = m_data->handlers.begin(); it != m_data->handlers.end(); ++it) {

--- a/thevoid/server.hpp
+++ b/thevoid/server.hpp
@@ -130,6 +130,11 @@ public:
 	void stop();
 
 	/*!
+	 * \brief Reloads server's configuration.
+	 */
+	void reload();
+
+	/*!
 	 * \brief Returns logger of the service.
 	 */
 	const swarm::logger &logger() const;


### PR DESCRIPTION
This method is aimed to request server to reload its configuration.
    
By now this method does nothing (as well as underlying implementation server_data::handle_reload()).

Merge #38 first.