### PR TITLE
Fix request completion

### DIFF
--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -470,12 +470,7 @@ void connection<T>::close_impl(const boost::system::error_code &err)
 	if (m_state != processing_request) {
 		m_state |= request_processed;
 
-		m_pause_receive = false;
-		if (m_unprocessed_begin != m_unprocessed_end) {
-			process_data();
-		} else {
-			async_read();
-		}
+		want_more_impl();
 		return;
 	}
 

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -458,6 +458,14 @@ void connection<T>::close_impl(const boost::system::error_code &err)
 		return;
 	}
 
+	if (!m_keep_alive) {
+		print_access_log();
+		boost::system::error_code ignored_ec;
+		m_socket.shutdown(boost::asio::socket_base::shutdown_both, ignored_ec);
+		m_socket.close(ignored_ec);
+		return;
+	}
+
 	// Is request data is not fully received yet - receive it
 	if (m_state != processing_request) {
 		m_state |= request_processed;
@@ -468,14 +476,6 @@ void connection<T>::close_impl(const boost::system::error_code &err)
 		} else {
 			async_read();
 		}
-		return;
-	}
-
-	if (!m_keep_alive) {
-		print_access_log();
-		boost::system::error_code ignored_ec;
-		m_socket.shutdown(boost::asio::socket_base::shutdown_both, ignored_ec);
-		m_socket.close(ignored_ec);
 		return;
 	}
 

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -105,6 +105,7 @@ public:
 		std::function<void (const boost::system::error_code &err)> &&handler) /*override*/;
 	void want_more();
 	void pause_receive();
+	void send_error(http_response::status_type type);
 	virtual void initialize(base_request_stream_data *data);
 	virtual swarm::logger create_logger();
 	virtual void close(const boost::system::error_code &err) /*override*/;
@@ -128,7 +129,7 @@ private:
 
 	void async_read();
 
-	void send_error(http_response::status_type type);
+	void send_error_impl(http_response::status_type type);
 
 	template <size_t N>
 	inline void add_state_attribute(std::ostringstream &out, bool &first, state st, const char (&name) [N])


### PR DESCRIPTION
Fixes #43 by using `connection::want_more_impl` to receive remaining request data. That method appropriately handles current request's state, its content-length and the amount of already received data.

Fixes #44 by reordering conditions checks within `connection::close_impl` (checks keep-alive first).
`reply_stream::send_error` reworked to close the connection with the client forcibly. `m_close_invoked` is set to do not call any handler's methods (which is hacky, but should work) and keep-alive is unset, that will force the connection to close.

Actually, the true solution would be to introduce request's (and connection's) state machine with valid transitions, etc.