### PR TITLE
Support premature connection close with Connection header

### DIFF
--- a/swarm/http_headers.cpp
+++ b/swarm/http_headers.cpp
@@ -29,10 +29,9 @@ namespace swarm {
 #define IF_MODIFIED_SINCE_HEADER "If-Modified-Since"
 #define CONNECTION_HEADER "Connection"
 #define CONNECTION_HEADER_KEEP_ALIVE "Keep-Alive"
+#define CONNECTION_HEADER_CLOSE "Close"
 #define CONTENT_LENGTH_HEADER "Content-Length"
 #define CONTENT_TYPE_HEADER "Content-Type"
-#define CONNECTION_HEADER "Connection"
-#define CONNECTION_HEADER_KEEP_ALIVE "Keep-Alive"
 
 static bool are_case_insensitive_equal(const std::string &first, const char *second, const size_t second_size)
 {
@@ -522,6 +521,16 @@ boost::optional<std::string> http_headers::connection() const
 void http_headers::set_keep_alive()
 {
 	set_connection(CONNECTION_HEADER_KEEP_ALIVE);
+}
+
+void http_headers::set_keep_alive(bool keep_alive)
+{
+	if (keep_alive) {
+		set_connection(CONNECTION_HEADER_KEEP_ALIVE);
+	}
+	else {
+		set_connection(CONNECTION_HEADER_CLOSE);
+	}
 }
 
 boost::optional<bool> http_headers::is_keep_alive() const

--- a/swarm/http_headers.cpp
+++ b/swarm/http_headers.cpp
@@ -28,10 +28,11 @@ namespace swarm {
 #define LAST_MODIFIED_HEADER "Last-Modified"
 #define IF_MODIFIED_SINCE_HEADER "If-Modified-Since"
 #define CONNECTION_HEADER "Connection"
-#define CONNECTION_HEADER_KEEP_ALIVE "Keep-Alive"
-#define CONNECTION_HEADER_CLOSE "Close"
 #define CONTENT_LENGTH_HEADER "Content-Length"
 #define CONTENT_TYPE_HEADER "Content-Type"
+
+const std::string http_headers::CONNECTION_KEEP_ALIVE = "Keep-Alive";
+const std::string http_headers::CONNECTION_CLOSE = "Close";
 
 static bool are_case_insensitive_equal(const std::string &first, const char *second, const size_t second_size)
 {
@@ -520,23 +521,23 @@ boost::optional<std::string> http_headers::connection() const
 
 void http_headers::set_keep_alive()
 {
-	set_connection(CONNECTION_HEADER_KEEP_ALIVE);
+	set_connection(CONNECTION_KEEP_ALIVE);
 }
 
 void http_headers::set_keep_alive(bool keep_alive)
 {
 	if (keep_alive) {
-		set_connection(CONNECTION_HEADER_KEEP_ALIVE);
+		set_connection(CONNECTION_KEEP_ALIVE);
 	}
 	else {
-		set_connection(CONNECTION_HEADER_CLOSE);
+		set_connection(CONNECTION_CLOSE);
 	}
 }
 
 boost::optional<bool> http_headers::is_keep_alive() const
 {
 	if (auto tmp = connection()) {
-		return are_case_insensitive_equal(*tmp, CONNECTION_HEADER_KEEP_ALIVE, sizeof(CONNECTION_HEADER_KEEP_ALIVE) - 1);
+		return are_case_insensitive_equal(*tmp, CONNECTION_KEEP_ALIVE.c_str(), CONNECTION_KEEP_ALIVE.size());
 	}
 
 	return boost::none;

--- a/swarm/http_headers.hpp
+++ b/swarm/http_headers.hpp
@@ -288,6 +288,7 @@ public:
 	 * \sa set_connection
 	 * \sa is_keep_alive
 	 */
+	__attribute__((deprecated("Use set_keep_alive(true) instead")))
 	void set_keep_alive();
 	/*!
 	 * \brief Returnes true if the value of Connection header is "Keep-Alive".

--- a/swarm/http_headers.hpp
+++ b/swarm/http_headers.hpp
@@ -272,6 +272,14 @@ public:
 	boost::optional<std::string> connection() const;
 
 	/*!
+	 * \brief Sets the value of the Connection header.
+	 * The value is set to "Keep-Alive" if true is specified, or to "Close" otherwise.
+	 *
+	 * \sa set_connection
+	 * \sa is_keep_alive
+	 */
+	void set_keep_alive(bool keep_alive);
+	/*!
 	 * \brief Sets the value of Connection header to "Keep-Alive".
 	 *
 	 * \sa set_connection

--- a/swarm/http_headers.hpp
+++ b/swarm/http_headers.hpp
@@ -39,6 +39,9 @@ typedef std::pair<std::string, std::string> headers_entry;
 class http_headers
 {
 public:
+	static const std::string CONNECTION_KEEP_ALIVE;
+	static const std::string CONNECTION_CLOSE;
+
 	/*!
 	 * \brief Constructs empty headers list.
 	 */

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -827,25 +827,11 @@ void connection<T>::send_error(http_response::status_type type)
 		("status", type)
 		("state", make_state_attribute());
 
-	// mark close_invoked to do not call any handler's methods
-	m_close_invoked = true;
+	auto response = stock_replies::stock_reply(type);
+	response.headers().set_keep_alive(false);
 
-	m_socket.get_io_service().dispatch(std::bind(&connection::send_error_impl, this->shared_from_this(), type));
-}
-
-template <typename T>
-void connection<T>::send_error_impl(http_response::status_type type)
-{
-	// unsetting keep-alive will force to terminate the connection
-	m_keep_alive = false;
-
-	// with processing_request state want_more() and process_data()
-	// calls will be ignored
-	m_state = processing_request;
-
-	send_headers(stock_replies::stock_reply(type),
-		boost::asio::const_buffer(),
-		std::bind(&connection::close_impl, this->shared_from_this(), std::placeholders::_1));
+	send_headers(std::move(response), boost::asio::const_buffer(), result_function());
+	close(boost::system::error_code());
 }
 
 template class connection<boost::asio::local::stream_protocol::socket>;

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -174,8 +174,14 @@ void connection<T>::send_headers(http_response &&rep,
 {
 	m_access_status = rep.code();
 
-	if (m_keep_alive) {
-		rep.headers().set_keep_alive();
+	if (!m_keep_alive) {
+		// if connection cannot be reused, send "Connection: Close"
+		rep.headers().set_keep_alive(false);
+	}
+	else if (auto keep_alive = rep.headers().is_keep_alive()) {
+		// connection is reusable, but handler set Connection header explicitly
+		// let's just use it
+		m_keep_alive = *keep_alive;
 	}
 
 	CONNECTION_DEBUG("handler sends headers to client")

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -129,8 +129,6 @@ private:
 
 	void async_read();
 
-	void send_error_impl(http_response::status_type type);
-
 	template <size_t N>
 	inline void add_state_attribute(std::ostringstream &out, bool &first, state st, const char (&name) [N])
 	{


### PR DESCRIPTION
`http_headers::set_keep_alive(bool)` method added.

With this method one can explicitly state that the connection should be reused or not. Still if connection cannot be reused due to "Connection: Close" in the client's request or due to some internal problems, this method will not affect actual Connection header in the response.

`reply_stream::send_error()` method reworked using the introduced functionality.

Fixes #50 

Reviewers: @iderikon 