### PR TITLE
add timings of receiving/sending data to client to access log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(swarm)
 cmake_minimum_required(VERSION 2.6)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -W -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -W -Wall -Wextra -D_GLIBCXX_USE_CLOCK_MONOTONIC")
 
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/debian/changelog" DEBCHANGELOG)
 

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -311,11 +311,14 @@ void connection<T>::send_impl(buffer_info &&info)
 template <typename T>
 void connection<T>::write_finished(const boost::system::error_code &err, size_t bytes_written)
 {
+	auto write_time = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - m_send_start);
+	m_send_time += write_time;
 	m_access_sent += bytes_written;
 
 	CONNECTION_LOG(err ? SWARM_LOG_ERROR : SWARM_LOG_DEBUG, "write to client finished")
 		("error", err.message())
-		("size", bytes_written);
+		("size", bytes_written)
+		("time", write_time.count());
 
 	if (err) {
 		decltype(m_outgoing) outgoing;
@@ -431,6 +434,8 @@ void connection<T>::send_nolock()
 {
 	buffers_array data(m_outgoing.begin(), m_outgoing.end());
 
+	m_send_start = std::chrono::steady_clock::now();
+
 	m_socket.async_write_some(data, detail::attributes_bind(m_logger, m_attributes, std::bind(
 		&connection::write_finished, this->shared_from_this(),
 		std::placeholders::_1, std::placeholders::_2)));
@@ -505,6 +510,9 @@ void connection<T>::process_next()
 	m_content_length = 0;
 	m_pause_receive = false;
 
+	m_receive_time = std::chrono::microseconds();
+	m_send_time = std::chrono::microseconds();
+
 	m_attributes.clear();
 	m_logger = swarm::logger(m_base_logger, m_attributes);
 	m_request = http_request();
@@ -534,7 +542,8 @@ void connection<T>::print_access_log()
 
 	unsigned long long delta = 1000000ull * (end.tv_sec - m_access_start.tv_sec) + end.tv_usec - m_access_start.tv_usec;
 
-	CONNECTION_LOG(SWARM_LOG_INFO, "access_log_entry: method: %s, url: %s, local: %s, remote: %s, status: %d, received: %llu, sent: %llu, time: %llu us",
+	CONNECTION_LOG(SWARM_LOG_INFO, "access_log_entry: method: %s, url: %s, local: %s, remote: %s, status: %d, received: %llu, sent: %llu, time: %llu us, "
+			"receive_time: %lld us, send_time: %lld us",
 		m_access_method.empty() ? "-" : m_access_method.c_str(),
 		m_access_url.empty() ? "-" : m_access_url.c_str(),
 		m_access_local.c_str(),
@@ -542,12 +551,17 @@ void connection<T>::print_access_log()
 		m_access_status,
 		m_access_received,
 		m_access_sent,
-		delta);
+		delta,
+		m_receive_time.count(),
+		m_send_time.count());
 }
 
 template <typename T>
 void connection<T>::handle_read(const boost::system::error_code &err, std::size_t bytes_transferred)
 {
+	auto read_time = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - m_receive_start);
+	m_receive_time += read_time;
+
 	m_at_read = false;
 
 	// This message is not error in case of disconnect between requests
@@ -559,7 +573,8 @@ void connection<T>::handle_read(const boost::system::error_code &err, std::size_
 		("error", err.message())
 		("real_error", error)
 		("state", make_state_attribute())
-		("size", bytes_transferred);
+		("size", bytes_transferred)
+		("time", read_time.count());
 
 	if (err) {
 		if (m_access_status == 0 || !m_request_processing_was_finished) {
@@ -806,6 +821,8 @@ void connection<T>::async_read()
 
 	CONNECTION_DEBUG("request read from client")
 		("state", make_state_attribute());
+
+	m_receive_start = std::chrono::steady_clock::now();
 
 	m_socket.async_read_some(boost::asio::buffer(m_buffer),
 		detail::attributes_bind(m_logger, m_attributes,

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -17,18 +17,21 @@
 #ifndef IOREMAP_THEVOID_CONNECTION_P_HPP
 #define IOREMAP_THEVOID_CONNECTION_P_HPP
 
+#include <queue>
+#include <mutex>
+
 #include <boost/asio.hpp>
 #include <boost/array.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
-#include "http_request.hpp"
-#include "request_parser_p.hpp"
-#include "stream.hpp"
-#include <queue>
-#include <mutex>
 
 #include <blackhole/utils/atomic.hpp>
+
+#include "stream.hpp"
+#include "http_request.hpp"
+
+#include "request_parser_p.hpp"
 
 namespace ioremap {
 namespace thevoid {

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -131,7 +131,8 @@ private:
 
 	void want_more_impl();
 	void send_impl(buffer_info &&info);
-	void write_finished(const boost::system::error_code &err, size_t bytes_written);
+	void write_finished(const boost::system::error_code &err, size_t bytes_written,
+			std::chrono::steady_clock::time_point start_time);
 	void send_nolock();
 
 	void close_impl(const boost::system::error_code &err);
@@ -139,7 +140,8 @@ private:
 	void print_access_log();
 
 	//! Handle completion of a read operation.
-	void handle_read(const boost::system::error_code &err, std::size_t bytes_transferred);
+	void handle_read(const boost::system::error_code &err, std::size_t bytes_transferred,
+			std::chrono::steady_clock::time_point start_time);
 	void process_data();
 
 	void async_read();
@@ -229,10 +231,7 @@ private:
 
 	bool m_pause_receive;
 
-	std::chrono::steady_clock::time_point m_receive_start;
 	std::chrono::microseconds m_receive_time;
-
-	std::chrono::steady_clock::time_point m_send_start;
 	std::chrono::microseconds m_send_time;
 };
 

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -19,6 +19,7 @@
 
 #include <queue>
 #include <mutex>
+#include <chrono>
 
 #include <boost/asio.hpp>
 #include <boost/array.hpp>
@@ -32,6 +33,17 @@
 #include "http_request.hpp"
 
 #include "request_parser_p.hpp"
+
+// GCC prior to 4.7 uses an obsolete name for steady_clock
+#if __GNUC__ == 4 && __GNUC_MINOR__ < 7
+namespace std {
+namespace chrono {
+
+typedef monotonic_clock steady_clock;
+
+} // namespace chrono
+} // namespace std
+#endif
 
 namespace ioremap {
 namespace thevoid {
@@ -216,6 +228,12 @@ private:
 	const char *m_unprocessed_end;
 
 	bool m_pause_receive;
+
+	std::chrono::steady_clock::time_point m_receive_start;
+	std::chrono::microseconds m_receive_time;
+
+	std::chrono::steady_clock::time_point m_send_start;
+	std::chrono::microseconds m_send_time;
 };
 
 typedef connection<boost::asio::ip::tcp::socket> tcp_connection;


### PR DESCRIPTION
Overall timings 'receive_time' and 'send_time' added to the log. On each read and write operation its time added to the log. All times are in microseconds.

Closes #46 

------------------------------
`std::chrono::steady_clock` clock is used to measure time intervals. Prior to GCC 4.7 `steady_clock` was named `monotonic_clock`. Still there're some doubts about this clock's monotonicity support in different compilers.