### PR TITLE
add timings of receiving/sending data to client to access log

### DIFF
--- a/thevoid/CMakeLists.txt
+++ b/thevoid/CMakeLists.txt
@@ -6,7 +6,7 @@ message("Boost_LIBRARIES: ${Boost_LIBRARIES}")
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_link_libraries(thevoid ${Boost_LIBRARIES} pthread swarm)
+target_link_libraries(thevoid rt ${Boost_LIBRARIES} pthread swarm)
 set_target_properties(thevoid PROPERTIES
     VERSION ${DEBFULLVERSION}
     SOVERSION ${SWARM_VERSION_ABI}

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -23,6 +23,70 @@
 #include "stream_p.hpp"
 #include "stockreplies_p.hpp"
 
+namespace {
+
+const long int USECS_IN_SEC = 1000 * 1000;
+const long int NSECS_IN_SEC = USECS_IN_SEC * 1000;
+
+struct timespec& operator+= (struct timespec& lhs, const struct timespec& rhs) {
+	lhs.tv_sec += rhs.tv_sec;
+	lhs.tv_nsec += rhs.tv_nsec;
+
+	if (lhs.tv_nsec >= NSECS_IN_SEC) {
+		lhs.tv_sec += 1;
+		lhs.tv_nsec -= NSECS_IN_SEC;
+	}
+
+	return lhs;
+}
+
+struct timespec operator+ (const struct timespec& lhs, const struct timespec& rhs) {
+	struct timespec res(lhs);
+	res += rhs;
+	return res;
+}
+
+struct timespec& operator-= (struct timespec& lhs, const struct timespec& rhs) {
+	lhs.tv_sec -= rhs.tv_sec;
+	lhs.tv_nsec -= rhs.tv_nsec;
+
+	if (lhs.tv_nsec < 0) {
+		lhs.tv_sec -= 1;
+		lhs.tv_nsec += NSECS_IN_SEC;
+	}
+
+	if (lhs.tv_sec < 0) {
+		lhs = {0, 0};
+	}
+
+	return lhs;
+}
+
+struct timespec operator- (const struct timespec& lhs, const struct timespec& rhs) {
+	struct timespec res(lhs);
+	res -= rhs;
+	return res;
+}
+
+long int timespec_to_usec(const struct timespec& t) {
+	return t.tv_sec * USECS_IN_SEC + t.tv_nsec / 1000;
+}
+
+struct timespec gettime_now() {
+	struct timespec now;
+
+#ifdef CLOCK_MONOTONIC_RAW
+	if (clock_gettime(CLOCK_MONOTONIC_RAW, &now) == 0) {
+		return now;
+	}
+#endif
+
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	return now;
+}
+
+} // unnamed namespace
+
 namespace ioremap {
 namespace thevoid {
 
@@ -101,7 +165,9 @@ connection<T>::connection(base_server *server, boost::asio::io_service &service,
 	m_sending(false),
 	m_keep_alive(false),
 	m_at_read(false),
-	m_pause_receive(false)
+	m_pause_receive(false),
+	m_receive_time{0, 0},
+	m_send_time{0, 0}
 {
 	m_unprocessed_begin = m_buffer.data();
 	m_unprocessed_end = m_buffer.data();
@@ -309,13 +375,17 @@ void connection<T>::send_impl(buffer_info &&info)
 }
 
 template <typename T>
-void connection<T>::write_finished(const boost::system::error_code &err, size_t bytes_written)
+void connection<T>::write_finished(const boost::system::error_code &err, size_t bytes_written,
+		struct timespec start_time)
 {
+	auto write_time = gettime_now() - start_time;
+	m_send_time += write_time;
 	m_access_sent += bytes_written;
 
 	CONNECTION_LOG(err ? SWARM_LOG_ERROR : SWARM_LOG_DEBUG, "write to client finished")
 		("error", err.message())
-		("size", bytes_written);
+		("size", bytes_written)
+		("time", timespec_to_usec(write_time));
 
 	if (err) {
 		decltype(m_outgoing) outgoing;
@@ -431,9 +501,11 @@ void connection<T>::send_nolock()
 {
 	buffers_array data(m_outgoing.begin(), m_outgoing.end());
 
+	auto send_start = gettime_now();
+
 	m_socket.async_write_some(data, detail::attributes_bind(m_logger, m_attributes, std::bind(
 		&connection::write_finished, this->shared_from_this(),
-		std::placeholders::_1, std::placeholders::_2)));
+		std::placeholders::_1, std::placeholders::_2, send_start)));
 }
 
 template <typename T>
@@ -505,6 +577,9 @@ void connection<T>::process_next()
 	m_content_length = 0;
 	m_pause_receive = false;
 
+	m_receive_time = {0, 0};
+	m_send_time = {0, 0};
+
 	m_attributes.clear();
 	m_logger = swarm::logger(m_base_logger, m_attributes);
 	m_request = http_request();
@@ -534,7 +609,8 @@ void connection<T>::print_access_log()
 
 	unsigned long long delta = 1000000ull * (end.tv_sec - m_access_start.tv_sec) + end.tv_usec - m_access_start.tv_usec;
 
-	CONNECTION_LOG(SWARM_LOG_INFO, "access_log_entry: method: %s, url: %s, local: %s, remote: %s, status: %d, received: %llu, sent: %llu, time: %llu us",
+	CONNECTION_LOG(SWARM_LOG_INFO, "access_log_entry: method: %s, url: %s, local: %s, remote: %s, status: %d, received: %llu, sent: %llu, time: %llu us, "
+			"receive_time: %ld us, send_time: %ld us",
 		m_access_method.empty() ? "-" : m_access_method.c_str(),
 		m_access_url.empty() ? "-" : m_access_url.c_str(),
 		m_access_local.c_str(),
@@ -542,12 +618,18 @@ void connection<T>::print_access_log()
 		m_access_status,
 		m_access_received,
 		m_access_sent,
-		delta);
+		delta,
+		timespec_to_usec(m_receive_time),
+		timespec_to_usec(m_send_time));
 }
 
 template <typename T>
-void connection<T>::handle_read(const boost::system::error_code &err, std::size_t bytes_transferred)
+void connection<T>::handle_read(const boost::system::error_code &err, std::size_t bytes_transferred,
+		struct timespec start_time)
 {
+	auto read_time = gettime_now() - start_time;
+	m_receive_time += read_time;
+
 	m_at_read = false;
 
 	// This message is not error in case of disconnect between requests
@@ -559,7 +641,8 @@ void connection<T>::handle_read(const boost::system::error_code &err, std::size_
 		("error", err.message())
 		("real_error", error)
 		("state", make_state_attribute())
-		("size", bytes_transferred);
+		("size", bytes_transferred)
+		("time", timespec_to_usec(read_time));
 
 	if (err) {
 		if (m_access_status == 0 || !m_request_processing_was_finished) {
@@ -807,11 +890,14 @@ void connection<T>::async_read()
 	CONNECTION_DEBUG("request read from client")
 		("state", make_state_attribute());
 
+	auto receive_start = gettime_now();
+
 	m_socket.async_read_some(boost::asio::buffer(m_buffer),
 		detail::attributes_bind(m_logger, m_attributes,
 			std::bind(&connection::handle_read, this->shared_from_this(),
 				std::placeholders::_1,
-				std::placeholders::_2)));
+				std::placeholders::_2,
+				receive_start)));
 }
 
 template <typename T>

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -40,10 +40,8 @@ struct timespec& operator+= (struct timespec& lhs, const struct timespec& rhs) {
 	return lhs;
 }
 
-struct timespec operator+ (const struct timespec& lhs, const struct timespec& rhs) {
-	struct timespec res(lhs);
-	res += rhs;
-	return res;
+struct timespec operator+ (struct timespec lhs, const struct timespec& rhs) {
+	return lhs += rhs;
 }
 
 struct timespec& operator-= (struct timespec& lhs, const struct timespec& rhs) {
@@ -62,10 +60,8 @@ struct timespec& operator-= (struct timespec& lhs, const struct timespec& rhs) {
 	return lhs;
 }
 
-struct timespec operator- (const struct timespec& lhs, const struct timespec& rhs) {
-	struct timespec res(lhs);
-	res -= rhs;
-	return res;
+struct timespec operator- (struct timespec lhs, const struct timespec& rhs) {
+	return lhs -= rhs;
 }
 
 long int timespec_to_usec(const struct timespec& t) {

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -222,6 +222,7 @@ private:
 
 	struct timespec m_receive_time;
 	struct timespec m_send_time;
+	struct timespec m_starttransfer_time;
 };
 
 typedef connection<boost::asio::ip::tcp::socket> tcp_connection;

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -220,8 +220,16 @@ private:
 
 	bool m_pause_receive;
 
+	//! Total time of receiving data from the client.
+	//! This value is presented within access_log_entry as 'receive_time'.
 	struct timespec m_receive_time;
+
+	//! Total time of sending data to the client.
+	//! This value is presented within access_log_entry as 'send_time'.
 	struct timespec m_send_time;
+
+	//! Time from the start until the first chunk of data is received.
+	//! This value is presented within access_log_entry as 'starttransfer_time'.
 	struct timespec m_starttransfer_time;
 };
 

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -17,18 +17,21 @@
 #ifndef IOREMAP_THEVOID_CONNECTION_P_HPP
 #define IOREMAP_THEVOID_CONNECTION_P_HPP
 
+#include <queue>
+#include <mutex>
+
 #include <boost/asio.hpp>
 #include <boost/array.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
-#include "http_request.hpp"
-#include "request_parser_p.hpp"
-#include "stream.hpp"
-#include <queue>
-#include <mutex>
 
 #include <blackhole/utils/atomic.hpp>
+
+#include "stream.hpp"
+#include "http_request.hpp"
+
+#include "request_parser_p.hpp"
 
 namespace ioremap {
 namespace thevoid {

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -19,6 +19,7 @@
 
 #include <queue>
 #include <mutex>
+#include <ctime>
 
 #include <boost/asio.hpp>
 #include <boost/array.hpp>
@@ -119,7 +120,8 @@ private:
 
 	void want_more_impl();
 	void send_impl(buffer_info &&info);
-	void write_finished(const boost::system::error_code &err, size_t bytes_written);
+	void write_finished(const boost::system::error_code &err, size_t bytes_written,
+			struct timespec start_time);
 	void send_nolock();
 
 	void close_impl(const boost::system::error_code &err);
@@ -127,7 +129,8 @@ private:
 	void print_access_log();
 
 	//! Handle completion of a read operation.
-	void handle_read(const boost::system::error_code &err, std::size_t bytes_transferred);
+	void handle_read(const boost::system::error_code &err, std::size_t bytes_transferred,
+			struct timespec start_time);
 	void process_data();
 
 	void async_read();
@@ -216,6 +219,9 @@ private:
 	const char *m_unprocessed_end;
 
 	bool m_pause_receive;
+
+	struct timespec m_receive_time;
+	struct timespec m_send_time;
 };
 
 typedef connection<boost::asio::ip::tcp::socket> tcp_connection;


### PR DESCRIPTION
Overall timings 'receive_time' and 'send_time' added to the log. On each read and write operation its time added to the log. All times are in microseconds.

Closes #46