### PR TITLE
Run tests after build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,21 @@
 Source: swarm
 Priority: extra
 Maintainer: Ruslan Nigmatullin <euroelessar@yandex.ru>
-Build-Depends: cdbs, debhelper (>= 7), cmake, liburiparser-dev, libcurl4-openssl-dev, libxml2-dev,
-  libev-dev, libboost-system-dev, libboost-regex-dev, libboost-thread-dev,
-  libboost-program-options-dev, libboost-filesystem-dev, libidn11-dev, blackhole-dev (>= 0.2.2-1)
+Build-Depends:
+	cdbs,
+	debhelper (>= 7),
+	cmake,
+	liburiparser-dev,
+	libcurl4-openssl-dev,
+	libxml2-dev,
+	libev-dev,
+	libboost-system-dev,
+	libboost-regex-dev,
+	libboost-thread-dev,
+	libboost-program-options-dev,
+	libboost-filesystem-dev,
+	libidn11-dev,
+	blackhole-dev (>= 0.2.2-1),
 Standards-Version: 3.9.3
 Section: libs
 Homepage: https://github.com/reverbrain/swarm
@@ -13,25 +25,38 @@ Vcs-Browser: https://github.com/reverbrain/swarm
 Package: libswarm3
 Section: libs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends:
+	${shlibs:Depends},
+	${misc:Depends},
 Description: Swarm is aiming at your web
 
 Package: libswarm-urlfetcher3
 Section: libs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libswarm3 (= ${binary:Version})
+Depends:
+	${shlibs:Depends},
+	${misc:Depends},
+	libswarm3 (= ${binary:Version}),
 Description: Swarm is aiming at your web. Url fetch tools
 
 Package: libswarm-xml3
 Section: libs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends:
+	${shlibs:Depends},
+	${misc:Depends},
 Description: Swarm is aiming at your web. HTTP-parsing tools
 
 Package: libswarm3-dev
 Section: libdevel
 Architecture: any
-Depends: libswarm3 (= ${binary:Version}), libswarm-urlfetcher3 (= ${binary:Version}), libswarm-xml3 (= ${binary:Version}), libev-dev, libboost-system-dev, blackhole-dev
+Depends:
+	libswarm3 (= ${binary:Version}),
+	libswarm-urlfetcher3 (= ${binary:Version}),
+	libswarm-xml3 (= ${binary:Version}),
+	libev-dev,
+	libboost-system-dev,
+	blackhole-dev,
 Provides: libswarm-dev-virtual
 Conflicts: libswarm-dev-virtual
 Description: Swarm is aiming at your web (devel)
@@ -40,20 +65,34 @@ Description: Swarm is aiming at your web (devel)
 Package: libswarm3-dbg
 Architecture: any
 Section: debug
-Depends: ${shlibs:Depends}, ${misc:Depends}, libswarm3 (= ${binary:Version}), libthevoid3 (= ${binary:Version}), libswarm-urlfetcher3 (= ${binary:Version}), libswarm-xml3 (= ${binary:Version})
+Depends:
+	${shlibs:Depends},
+	${misc:Depends},
+	libswarm3 (= ${binary:Version}),
+	libthevoid3 (= ${binary:Version}),
+	libswarm-urlfetcher3 (= ${binary:Version}),
+	libswarm-xml3 (= ${binary:Version}),
 Description: Swarm is aiming at your web (debug)
  Debug files and symbols.
 
 Package: libthevoid3
 Section: libs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libswarm3 (= ${binary:Version})
+Depends:
+	${shlibs:Depends},
+	${misc:Depends},
+	libswarm3 (= ${binary:Version}),
 Description: TheVoid
 
 Package: libthevoid3-dev
 Section: libdevel
 Architecture: any
-Depends: libthevoid3 (= ${binary:Version}), libswarm3-dev (= ${binary:Version}), libboost-system-dev, libboost-thread-dev, libboost-regex-dev
+Depends:
+	libthevoid3 (= ${binary:Version}),
+	libswarm3-dev (= ${binary:Version}),
+	libboost-system-dev,
+	libboost-thread-dev,
+	libboost-regex-dev,
 Provides: libthevoid-dev-virtual
 Conflicts: libthevoid-dev-virtual
 Description: TheVoid (devel)

--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Build-Depends:
 	libboost-filesystem-dev,
 	libidn11-dev,
 	blackhole-dev (>= 0.2.2-1),
+	python-virtualenv,
 Standards-Version: 3.9.3
 Section: libs
 Homepage: https://github.com/reverbrain/swarm

--- a/debian/rules
+++ b/debian/rules
@@ -4,3 +4,5 @@ DEB_DBG_PACKAGES := libswarm3-dbg
 
 include /usr/share/cdbs/1/class/cmake.mk
 include /usr/share/cdbs/1/rules/debhelper.mk
+
+DEB_MAKE_CHECK_TARGET = check

--- a/libswarm-bf.spec
+++ b/libswarm-bf.spec
@@ -32,6 +32,7 @@ BuildRequires: cmake
 BuildRequires: uriparser-devel
 BuildRequires: libidn-devel
 BuildRequires: libblackhole-devel
+BuildRequires: python-virtualenv
 
 %description
 Swarm is high-performance library for web crawling.
@@ -87,6 +88,9 @@ TheVoid is asynchronious event-driven C++ library for building high-perfomance w
 %{cmake} -DPERF=off .
 
 make %{?_smp_mflags}
+
+%check
+make check
 
 %install
 rm -rf %{buildroot}

--- a/libswarm-bf.spec
+++ b/libswarm-bf.spec
@@ -13,16 +13,24 @@ Source0:	%{name}-%{version}.tar.bz2
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %if %{defined rhel} && 0%{?rhel} < 6
-BuildRequires:	gcc44 gcc44-c++
+BuildRequires: gcc44
+BuildRequires: gcc44-c++
 %define boost_ver 141
 %else
 %define boost_ver %{nil}
 %endif
-BuildRequires: libxml2-devel libev-devel
-BuildRequires: boost%{boost_ver}-devel, boost%{boost_ver}-iostreams, boost%{boost_ver}-system, boost%{boost_ver}-thread, boost%{boost_ver}-regex, boost%{boost_ver}-filesystem
+BuildRequires: libxml2-devel
+BuildRequires: libev-devel
+BuildRequires: boost%{boost_ver}-devel
+BuildRequires: boost%{boost_ver}-iostreams
+BuildRequires: boost%{boost_ver}-system
+BuildRequires: boost%{boost_ver}-thread
+BuildRequires: boost%{boost_ver}-regex
+BuildRequires: boost%{boost_ver}-filesystem
 BuildRequires: curl-devel
 BuildRequires: cmake
-BuildRequires: uriparser-devel libidn-devel
+BuildRequires: uriparser-devel
+BuildRequires: libidn-devel
 BuildRequires: libblackhole-devel
 
 %description

--- a/tests/test_broken_client.py
+++ b/tests/test_broken_client.py
@@ -44,9 +44,6 @@ def test_connection_close_before_request_finished(server, io_stream, http_connec
     io_stream.close()
 
     # wait for 'access_log_entry' and check its status
-    for log_line in iter(server.process.stdout.readline, b''):
-        if 'access_log_entry' in log_line:
-            assert 'status: 499' in log_line
-            break
-    else:
-        pytest.fail('no access_log_entry in server log')
+    yield server.process.stdout.read_until('access_log_entry')
+    access_log_line = yield server.process.stdout.read_until('\n')
+    assert 'status: 499' in access_log_line

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -92,3 +92,14 @@ def test_handler_headers_user_agent_pytest(server, user_agent):
 def test_handler_not_found(server):
     response = requests.get(server.request_url('/no-such-handler'))
     assert response.status_code == requests.codes.not_found
+
+
+@pytest.mark.server_options(
+    log_level='error',
+)
+@pytest.mark.async_test(timeout=0.5)
+@pytest.mark.xfail
+def test_invalid_server_log_level(server):
+    # on 'error' log level necessary log lines ('Start to listen address')
+    # will not be printed and server's start will fail
+    pass

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -3,18 +3,18 @@ import requests
 
 
 @pytest.mark.server_options(
-    port=1111, backlog=256,
-    threads=16, buffer_size=1024,
-    log_level='debug', monitor_port=20000)
+    backlog=256,
+    threads=16,
+    buffer_size=1024,
+    log_level='debug',
+)
 def test_server_options(server):
     opts = server.opts
 
-    assert opts['port'] == 1111
     assert opts['backlog'] == 256
     assert opts['threads'] == 16
     assert opts['buffer_size'] == 1024
     assert opts['log_level'] == 'debug'
-    assert opts['monitor_port'] == 20000
 
 
 @pytest.mark.server_options(

--- a/thevoid/acceptorlist.cpp
+++ b/thevoid/acceptorlist.cpp
@@ -80,8 +80,7 @@ void acceptors_list<Connection>::add_acceptor(const std::string &address)
 
 		complete_socket_creation(endpoint);
 	} catch (boost::system::system_error &error) {
-		std::cerr << "Can not bind socket \"" << address << "\": " << error.what() << std::endl;
-		std::cerr.flush();
+		BH_LOG(data.logger, SWARM_LOG_ERROR, "Can not bind socket '%s': %s", address, error.what());
 
 		acceptors.pop_back();
 		if (local_endpoints.size() > acceptors.size())

--- a/thevoid/acceptorlist.cpp
+++ b/thevoid/acceptorlist.cpp
@@ -73,10 +73,12 @@ void acceptors_list<Connection>::add_acceptor(const std::string &address)
 		acceptor->bind(endpoint);
 		acceptor->listen(data.backlog_size);
 
-		BH_LOG(data.logger, SWARM_LOG_INFO, "Started to listen address: %s, backlog: %d",
-				boost::lexical_cast<std::string>(acceptor->local_endpoint()), data.backlog_size);
+		auto local_endpoint = boost::lexical_cast<std::string>(acceptor->local_endpoint());
 
-		local_endpoints.emplace_back(boost::lexical_cast<std::string>(endpoint));
+		BH_LOG(data.logger, SWARM_LOG_INFO, "Started to listen address: %s, backlog: %d",
+				local_endpoint, data.backlog_size);
+
+		local_endpoints.emplace_back(local_endpoint);
 		protocols.push_back(endpoint.protocol());
 
 		complete_socket_creation(endpoint);

--- a/thevoid/acceptorlist.cpp
+++ b/thevoid/acceptorlist.cpp
@@ -73,7 +73,8 @@ void acceptors_list<Connection>::add_acceptor(const std::string &address)
 		acceptor->bind(endpoint);
 		acceptor->listen(data.backlog_size);
 
-		BH_LOG(data.logger, SWARM_LOG_INFO, "Started to listen address: %s, backlog: %d", address, data.backlog_size);
+		BH_LOG(data.logger, SWARM_LOG_INFO, "Started to listen address: %s, backlog: %d",
+				boost::lexical_cast<std::string>(acceptor->local_endpoint()), data.backlog_size);
 
 		local_endpoints.emplace_back(boost::lexical_cast<std::string>(endpoint));
 		protocols.push_back(endpoint.protocol());


### PR DESCRIPTION
The main issue of the previous tests implementation was fixed -- random port generation was removed.
Instead port 0 is used and TheVoid server binds on unused port number.

Server's logs are used to get actual port number.
This was fixed in TheVoid too, previously TheVoid printed endpoint address from a config file as is.