### PR TITLE
Rework request's logs

### DIFF
--- a/example/server-config.json
+++ b/example/server-config.json
@@ -29,6 +29,7 @@
     "monitor-port": 20000,
     "request_header": "X-Request",
     "trace_header": "X-Trace",
+    "log_request_headers": ["User-Agent", "Authorization", "Cookie"],
     "application": {
     }
 }

--- a/tests/fixtures/server.py
+++ b/tests/fixtures/server.py
@@ -59,6 +59,7 @@ class Server(object):
         ]
     },
     "monitor-port": {{ monitor_port }},
+    "log_request_headers": {{ log_request_headers | tojson | safe }},
     "application": {
         "handlers": {{ handlers | tojson | safe }}
     }
@@ -72,6 +73,7 @@ class Server(object):
         self.opts['buffer_size'] = kwargs.get('buffer_size', 65536)
         self.opts['log_level'] = kwargs.get('log_level', 'info')
         self.opts['monitor_port'] = kwargs.get('monitor_port', 0)
+        self.opts['log_request_headers'] = kwargs.get('log_request_headers', [])
         self.opts['handlers'] = kwargs.get('handlers', [])
         self.config_file = None
 

--- a/tests/test_request_log.py
+++ b/tests/test_request_log.py
@@ -1,0 +1,151 @@
+import re
+
+import pytest
+import requests
+import tornado.gen
+
+
+@pytest.mark.parametrize(
+    'headers',
+    [
+        {
+            'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
+            'Accept-Encoding': '',
+            'Accept': 'application/json, text/json, text/x-json, text/javascript',
+            'Cookie': 'PHPSESSID=r2t5uvjq435r4q7ib3vtdjq120',
+            'Custom-Header': '"{\"custom\"\t\"header\"\t\"value\"}"',
+            'X-Pingback': 'http://www.example.org/xmlrpc.php',
+            'X-Cookie': '\tCustom \"Cookie\"\t',
+        },
+    ],
+)
+class TestLogRequestHeaders(object):
+    '''Sends empty GET request with custom headers and validates request's log headers.
+
+    Request's headers are logged within 'received new request' log line.
+    '''
+
+    def parse_headers(self, log_line):
+        # Header's key consists of non-whitespace characters except for double quote
+        #
+        # (?!") - asserts that what immediately follows the current position in the
+        # string is not a double quote
+        header_key_pattern = r'((?!")\S)+'
+
+        # Header's value consists of any character except for unescaped double quote
+        #
+        # (?<=\\)" - asserts that what immediately precedes the current position in
+        # the string is escape character and double quote is on the current position
+        #
+        # (?=(?<!\\)(\\\\)*") - asserts that double quote is on the current position
+        # in the string and even number of escapes immediately precede the current
+        # position
+        header_value_pattern = r'((?<=\\)"|[^"])*(?=(?<!\\)(\\\\)*")'
+
+        # Header is enclosed in double quoted and is followed by either ', ' or '}'
+        header_pattern = r'"(?P<key>{key}): (?P<value>{value})"(?=, |\}})'.format(
+            key=header_key_pattern,
+            value=header_value_pattern,
+        )
+
+        # Headers is a list of headers enclosed in '{', '}' and separated by ', '
+        #
+        # (, |(?=\}})) - asserts that ', ' is on the current position in the string
+        # or '}' immediately follows the current position
+        headers_pattern = r'headers: (?P<headers>\{{({header}(, |(?=\}})))*\}})'.format(
+            header=header_pattern,
+        )
+
+        headers_log_line = re.search(headers_pattern, log_line).group('headers')
+        log_headers = {
+            header.group('key'): header.group('value')
+            for header in re.finditer(header_pattern, headers_log_line)
+        }
+
+        return log_headers
+
+    @tornado.gen.coroutine
+    def request_log_line(self, server, method, url, headers):
+        requests.request(
+            method=method,
+            url=server.request_url(url),
+            headers=headers,
+        )
+
+        yield server.process.stdout.read_until('received new request: ')
+        log_line = yield server.process.stdout.read_until_regex('\n')
+
+        raise tornado.gen.Return(log_line)
+
+    @pytest.mark.server_options(
+        log_request_headers=[
+            'Accept-Charset',
+            'Accept-Encoding',
+            'Accept',
+            'Cookie',
+            'Custom-Header',
+        ],
+        handlers=[
+            {
+                'handler': 'echo',
+                'methods': ['GET'],
+                'exact_match': '/echo',
+            },
+        ],
+    )
+    @pytest.mark.async_test(timeout=0.5)
+    def test_log_request_headers(self, server, headers):
+        '''Test that only configured headers are printed.
+
+        Headers that start with 'X-' (like 'X-Pingback', 'X-Cookie') are not configured
+        to be logged, thus, they are checked to be not presented in the log.
+
+        Args:
+            server: an instance of `Server`.
+            headers: custom headers to send request with.
+        '''
+        log_line = yield self.request_log_line(
+            server=server,
+            method='GET',
+            url='/echo',
+            headers=headers,
+        )
+
+        log_headers = self.parse_headers(log_line)
+
+        for header_key, header_value in headers.iteritems():
+            if header_key.startswith('X-'):
+                assert header_key not in log_headers
+            else:
+                assert header_key in log_headers
+
+                log_header_value = log_headers[header_key]
+                assert log_header_value.decode('string_escape') == header_value
+
+    @pytest.mark.server_options(
+        log_request_headers=[],
+        handlers=[
+            {
+                'handler': 'echo',
+                'methods': ['GET'],
+                'exact_match': '/echo',
+            },
+        ],
+    )
+    @pytest.mark.async_test(timeout=0.5)
+    def test_log_request_headers_empty(self, server, headers):
+        '''Test that no logs are printed if config's log_request_headers is empty.
+
+        Args:
+            server: an instance of `Server`.
+            headers: custom headers to send request with.
+        '''
+        log_line = yield self.request_log_line(
+            server=server,
+            method='GET',
+            url='/echo',
+            headers=headers,
+        )
+
+        log_headers = self.parse_headers(log_line)
+        assert not log_headers

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -678,8 +678,11 @@ void connection<T>::process_next()
 	m_logger = swarm::logger(m_base_logger, m_attributes);
 	m_request = http_request();
 
-	CONNECTION_DEBUG("process next request")
-		("size", m_unprocessed_end - m_unprocessed_begin);
+	CONNECTION_INFO("process next request")
+		("size", m_unprocessed_end - m_unprocessed_begin)
+		("local", m_access_local)
+		("remote", m_access_remote)
+		;
 
 	if (m_unprocessed_begin != m_unprocessed_end) {
 		process_data();

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -88,9 +88,9 @@ struct timespec gettime_now() {
 namespace {
 
 template <typename InputIterator, typename OutputIterator>
-void escape(
-		const InputIterator& begin, const InputIterator& end,
-		OutputIterator& output,
+OutputIterator escape(
+		InputIterator begin, InputIterator end,
+		OutputIterator output,
 		int quote
 	)
 {
@@ -130,6 +130,8 @@ void escape(
 			output++ = ch;
 		}
 	}
+
+	return output;
 }
 
 std::string headers_to_string(
@@ -158,9 +160,9 @@ std::string headers_to_string(
 			}
 
 			output++ = quote;
-			std::copy(log_header.begin(), log_header.end(), output);
+			output = std::copy(log_header.begin(), log_header.end(), output);
 			output++ = ':'; output++ = ' ';
-			escape(header_value.begin(), header_value.end(), output, quote);
+			output = escape(header_value.begin(), header_value.end(), output, quote);
 			output++ = quote;
 		}
 	}

--- a/thevoid/server.cpp
+++ b/thevoid/server.cpp
@@ -524,6 +524,32 @@ int base_server::parse_arguments(int argc, char **argv)
 		return -7;
 	}
 
+	if (config.HasMember("log_request_headers")) {
+		auto& log_request_headers = config["log_request_headers"];
+
+		if (!log_request_headers.IsArray()) {
+			BH_LOG(logger(), SWARM_LOG_ERROR, "\"log_request_headers\" field is not an array");
+			return -8;
+		}
+
+		auto* headers_begin = log_request_headers.Begin();
+		auto* headers_end = log_request_headers.End();
+
+		for (auto* iter = headers_begin; iter != headers_end; ++iter) {
+			if (!iter->IsString()) {
+				BH_LOG(logger(), SWARM_LOG_ERROR, "\"log_request_headers\" field is not an array of strings");
+				return -8;
+			}
+		}
+
+		m_data->log_request_headers.clear();
+		for (auto* iter = headers_begin; iter != headers_end; ++iter) {
+			m_data->log_request_headers.push_back(
+					std::string(iter->GetString(), iter->GetStringLength())
+				);
+		}
+	}
+
 	m_data->options_parsed = true;
 
 	return 0;

--- a/thevoid/server_p.hpp
+++ b/thevoid/server_p.hpp
@@ -100,6 +100,9 @@ public:
 	//! Request ID/Trace bit
 	std::string request_header;
 	std::string trace_header;
+
+	//! Request headers to log
+	std::vector<std::string> log_request_headers;
 };
 
 }}


### PR DESCRIPTION
Adds log line with received new request's information, that includes:
- HTTP method
- URL
- local and remote endpoints
- headers in form of {"Header1: Value1", "Header2: Value2", ...}, values are escaped

The log line is printed on INFO log level.