### PR TITLE
thevoid/connection: close connection gracefully after sending the response

### DIFF
--- a/tests/handlers/delayed_error.cpp
+++ b/tests/handlers/delayed_error.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015+ Danil Osherov <shindo@yandex-team.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <memory>
+
+#include "thevoid/stream.hpp"
+
+#include "handlers_factory.hpp"
+
+
+namespace handlers {
+
+class delayed_error
+	: public ioremap::thevoid::buffered_request_stream<server>
+	, public std::enable_shared_from_this<delayed_error>
+{
+	virtual void on_request(const ioremap::thevoid::http_request& req)
+	{
+		code = req.url().query().item_value<int>("code", 403);
+		delay_size = req.url().query().item_value<size_t>("delay", -1);
+		response_data = req.url().query().item_value<std::string>("response", "");
+
+		auto chunk = req.url().query().item_value<int>("chunk", 1024);
+		set_chunk_size(chunk);
+
+		received = 0;
+
+		auto content_length = req.headers().content_length().get_value_or(0);
+
+		if (content_length == 0 || delay_size == 0) {
+			// send response right here
+			send_response();
+		} else {
+			try_next_chunk();
+		}
+	}
+
+	virtual void on_chunk(const boost::asio::const_buffer& buffer, unsigned int flags) {
+		received += boost::asio::buffer_size(buffer);
+
+		if (received >= delay_size || (flags & last_chunk)) {
+			send_response();
+		} else {
+			try_next_chunk();
+		}
+	}
+
+	virtual void on_error(const boost::system::error_code& /* err */) {
+	}
+
+private:
+	void send_response() {
+		ioremap::thevoid::http_response response;
+		response.set_code(code);
+		response.headers().set_content_length(response_data.size());
+		response.headers().set_keep_alive(false);
+
+		send_reply(std::move(response), std::move(response_data));
+	}
+
+	int code;
+	size_t delay_size;
+	std::string response_data;
+	size_t received;
+};
+
+} // namespace handlers
+
+REGISTER_HANDLER(delayed_error)

--- a/tests/test_graceful_close.py
+++ b/tests/test_graceful_close.py
@@ -1,0 +1,308 @@
+import pytest
+import urllib
+import requests
+import tornado.httputil
+
+from tornado.httputil import (
+    HTTPHeaders,
+    RequestStartLine
+)
+
+
+class ResponseHandler(tornado.httputil.HTTPMessageDelegate):
+    '''Handler that receives full response including body.
+
+    After the full response is received the connection will be closed.
+
+    Args:
+        expect_finish: whether finish() or on_connection_close() should be called.
+    '''
+    def __init__(self, expect_finish):
+        self.expect_finish = expect_finish
+        self.start_line = None
+        self.headers = None
+        self.data = ''
+
+    def headers_received(self, start_line, headers):
+        if (
+            self.start_line is not None or
+            self.headers is not None
+        ):
+            pytest.fail("ResponseHandler: headers may be received only once")
+
+        self.start_line = start_line
+        self.headers = headers
+
+    def data_received(self, chunk):
+        self.data += chunk
+
+    def finish(self):
+        if not self.expect_finish:
+            pytest.fail("ResponseHandler: finish() is not expected")
+
+    def on_connection_close(self):
+        if self.expect_finish:
+            pytest.fail("ResponseHandler: connection_close() is not expected")
+
+
+class DetachedResponseHandler(tornado.httputil.HTTPMessageDelegate):
+    '''Handler that receives response's headers and detaches from connection.
+
+    Args:
+        http_connection: an HTTP connection to detach from on received headers.
+    '''
+    def __init__(self, http_connection):
+        self.http_connection = http_connection
+        self.start_line = None
+        self.headers = None
+
+    def headers_received(self, start_line, headers):
+        if (
+            self.start_line is not None or
+            self.headers is not None
+        ):
+            pytest.fail("DetachedResponseHandler: headers may be received only once")
+
+        self.start_line = start_line
+        self.headers = headers
+
+        self.http_connection.detach()
+
+
+@pytest.mark.server_options(
+    handlers=[
+        {
+            'handler': 'delayed_error',
+            'prefix_match': '/delayed_error'
+        },
+    ],
+    log_level='debug',
+)
+@pytest.mark.parametrize(
+    'data,chunk',
+    [
+        (None, 1024),
+        (b'\x01' * 100 * 1024, 1024),
+    ],
+    ids=[
+        'empty',
+        '100 chunks',
+    ],
+)
+@pytest.mark.async_test(timeout=1)
+def test_no_graceful_close_on_full_request(server, data, chunk):
+    '''Sends full request and checks that server does no graceful close.
+
+    If server receives full request there's no need to do graceful close
+    and server closes the connection in usual way.
+
+    Args:
+        server: an instance of `Server`.
+        data: request's body.
+        chunk: handler's internal chunk size.
+    '''
+
+    # Start reading server's log until request's access log entry
+    request_log_future = server.process.stdout.read_until('access_log_entry')
+
+    code = 403
+    response = requests.post(
+        url=server.request_url('/delayed_error'),
+        params={
+            'code': code,
+            'delay': -1,
+            'chunk': chunk,
+        },
+        data=data,
+    )
+
+    assert response.status_code == code
+    assert response.headers['Connection'] == 'Close'
+
+    request_log = yield request_log_future
+    assert 'gracefully close the connection' not in request_log
+
+
+@pytest.mark.server_options(
+    handlers=[
+        {'handler': 'delayed_error',
+         'prefix_match': '/delayed_error'}
+    ],
+    log_level='debug',
+)
+@pytest.mark.parametrize(
+    'data',
+    [
+        b'\x01' * 100 * 1024,
+    ],
+    ids=[
+        '100Kb',
+    ],
+)
+@pytest.mark.async_test(timeout=1)
+def test_graceful_close_after_headers_server_close(server, io_stream, http_connection, data):
+    '''Sends request's headers and checks that server does graceful close.
+
+    If server receives request's and responds with error it should read request's
+    body. If client doesn't close the connection and sends the whole request server
+    should close the connection.
+
+    Args:
+        server: an instance of `Server`.
+        io_stream: an instance of `tornado.iostream.IOStream`.
+        http_connection:
+            An instance of `tornado.http1connection.HTTP1Connection` that uses `io_stream`
+            as underlying stream.
+        data: request's body.
+    '''
+
+    yield io_stream.connect(('localhost', server.opts['port']))
+
+    # Start reading server's log until request's access log entry
+    request_log_future = server.process.stdout.read_until('access_log_entry')
+
+    code = 403
+    response_data = 'response'
+    url = '/delayed_error?{}'.format(
+        urllib.urlencode({
+            'code': code,
+            'delay': 0,
+            'response': response_data,
+        })
+    )
+
+    start_line = RequestStartLine(method='POST', path=url, version='HTTP/1.1')
+    headers = HTTPHeaders({'Content-Length': str(len(data))})
+    yield http_connection.write_headers(start_line, headers)
+
+    # At this point server should respond with error
+    handler = DetachedResponseHandler(http_connection)
+    yield http_connection.read_response(handler)
+
+    assert handler.start_line.code == code
+    assert handler.headers['Content-Length'] == str(len(response_data))
+    assert handler.headers['Connection'] == 'Close'
+
+    # Continue sending request's body
+    yield io_stream.write(data)
+
+    # read the response's body
+    response = yield io_stream.read_bytes(len(response_data))
+    assert response == response_data
+
+    # At this point server should close the connection
+    with pytest.raises(tornado.iostream.StreamClosedError):
+        yield io_stream.read_bytes(1)
+
+    request_log = yield request_log_future
+    request_log_lines = request_log.split('\n')
+
+    graceful_close_log_start = [
+        log_line for log_line in request_log_lines
+        if 'gracefully close the connection' in log_line
+    ]
+    # graceful close log must apper only once
+    assert len(graceful_close_log_start) == 1
+    # state must include graceful_close
+    assert 'graceful_close' in graceful_close_log_start[0]
+
+
+@pytest.mark.server_options(
+    handlers=[
+        {'handler': 'delayed_error',
+         'prefix_match': '/delayed_error'}
+    ],
+    log_level='debug',
+)
+@pytest.mark.parametrize(
+    'data,server_delay',
+    [
+        (b'\x01' * 100 * 1024, 50 * 1024),
+        (b'\x01' * 100 * 1024, 25 * 1024),
+        (b'\x01' * 100 * 1024, 0),
+    ],
+    ids=[
+        'half',
+        'one-quarter',
+        'zero',
+    ],
+)
+@pytest.mark.async_test(timeout=1)
+def test_graceful_close_client_close_half_request(server, io_stream, http_connection, data,
+                                                  server_delay):
+    '''Sends request's headers and half of body and checks that server does graceful close.
+
+    If server receives request and responds with error it should read request's
+    body. If client closes the connection and sends only part of the request server
+    should not fail on closed connection.
+
+    Args:
+        server: an instance of `Server`.
+        io_stream: an instance of `tornado.iostream.IOStream`.
+        http_connection:
+            An instance of `tornado.http1connection.HTTP1Connection` that uses `io_stream`
+            as underlying stream.
+        data: request's body.
+        server_delay: part of request's body to receive before sending error response.
+    '''
+
+    yield io_stream.connect(('localhost', server.opts['port']))
+
+    # Start reading server's log until request's access log entry
+    request_log_future = server.process.stdout.read_until('access_log_entry')
+
+    code = 403
+    response_data = 'response'
+    url = '/delayed_error?{}'.format(
+        urllib.urlencode({
+            'code': code,
+            'delay': server_delay,
+            'response': response_data,
+        })
+    )
+
+    start_line = RequestStartLine(method='POST', path=url, version='HTTP/1.1')
+    headers = HTTPHeaders({'Content-Length': str(len(data))})
+    yield http_connection.write_headers(start_line, headers)
+    yield http_connection.write(data[:len(data) / 2])
+
+    # At this point server should respond with error
+    # handler will receive the response and close the connection
+    handler = ResponseHandler(http_connection)
+    yield http_connection.read_response(handler)
+
+    assert handler.start_line.code == code
+    assert handler.headers['Content-Length'] == str(len(response_data))
+    assert handler.headers['Connection'] == 'Close'
+    assert handler.data == response_data
+
+    # Ensure the connection in closed
+    with pytest.raises(tornado.iostream.StreamClosedError):
+        yield io_stream.write('test')
+
+    request_log = yield request_log_future
+    request_log_lines = request_log.split('\n')
+
+    graceful_close_log_start = [
+        log_line for log_line in request_log_lines
+        if 'gracefully close the connection' in log_line
+    ]
+    # graceful close log must apper only once
+    assert len(graceful_close_log_start) == 1
+    # state must include graceful_close
+    assert 'graceful_close' in graceful_close_log_start[0]
+
+    received_eof_log_lines = [
+        log_line for log_line in request_log_lines
+        if 'received new data' in log_line and 'End of file' in log_line
+    ]
+    # there should be only one log line with receive error
+    assert len(received_eof_log_lines) == 1
+    # state must include graceful_close
+    assert 'graceful_close' in received_eof_log_lines[0]
+    # log line must be printed on DEBUG log level as it's not an error
+    # during graceful close
+    assert (
+        'DEBUG' in received_eof_log_lines[0] and
+        'ERROR' not in received_eof_log_lines[0]
+    )

--- a/thevoid/connection_p.hpp
+++ b/thevoid/connection_p.hpp
@@ -88,7 +88,8 @@ public:
 		read_headers	   = 0x01,
 		read_data		  = 0x02,
 		request_processed  = 0x04,
-		waiting_for_first_data = 0x08
+		waiting_for_first_data = 0x08,
+		graceful_close = 0x10
 	};
 
 	//! Construct a connection with the given io_service.
@@ -158,6 +159,7 @@ private:
 		add_state_attribute(out, first, read_data, "read_data");
 		add_state_attribute(out, first, request_processed, "request_processed");
 		add_state_attribute(out, first, waiting_for_first_data, "waiting_for_first_data");
+		add_state_attribute(out, first, graceful_close, "graceful_close");
 
 		return out.str();
 	}


### PR DESCRIPTION
When server attempts to terminate request processing before the whole request was received it should close the connection gracefully after sending the response.

To do this server will read remaining request's body until either the whole request is received or the client closes the connection.

If server has received the whole request it may close the connection in a usual way (gracefully shutting down the socket).

If during graceful close the server fails on receiving remaining data from the client it means the client received the response and closed the connection by themself. In this case the server should not consider this fail as an error.

delayed_error handler is added that receives request by chunks ('chunk') and responds with specified status code ('code') after it has received specified amount of data ('delay'). All handler's options may be specified in URL query parameters.