### PR TITLE
spec: Remove mistakenly copied debian changelog

### DIFF
--- a/libswarm-bf.spec
+++ b/libswarm-bf.spec
@@ -128,17 +128,6 @@ rm -rf %{buildroot}
 %{_includedir}/thevoid/*
 %{_libdir}/libthevoid.so
 
-swarm (3.3.0) unstable; urgency=low
-
-  * fixed support for response's custom reason phrase.
-  * thevoid/connection: connection is closed gracefully after sending the
-    response.
-    When server attempts to terminate request processing before the whole
-    request was received it should close the connection gracefully after
-    sending the response.
-    To do this server will read remaining request's body until either the whole
-    request is received or the client closes the connection.
-
 %changelog
 * Fri Nov 27 2015 Danil Osherov <shindo@yandex-team.ru> - 3.3.0
 - fixed support for response's custom reason phrase.


### PR DESCRIPTION
I had mistakenly copied debian changelog here and forgot to remove it before committing.