### PR TITLE
* added HEAD, OPTIONS, PUT, DELETE, and PATCH HTTP methods

### DIFF
--- a/debian/libswarm3-dev.install
+++ b/debian/libswarm3-dev.install
@@ -1,2 +1,3 @@
 usr/include/swarm/*
 usr/lib*/libswarm.so
+usr/lib*/libswarm_urlfetcher.so

--- a/swarm/urlfetcher/url_fetcher.cpp
+++ b/swarm/urlfetcher/url_fetcher.cpp
@@ -45,7 +45,12 @@ typedef std::chrono::high_resolution_clock clock;
 
 enum http_command {
 	GET,
-	POST
+	HEAD,
+	OPTIONS,
+	POST,
+	PUT,
+	DELETE,
+	PATCH
 };
 
 std::atomic_int alive(0);
@@ -271,10 +276,37 @@ public:
 			headers_list = curl_slist_append(headers_list, line.c_str());
 		}
 
-		if (request->command == POST) {
-			curl_easy_setopt(info->easy, CURLOPT_POST, true);
+		switch (request->command) {
+		case HEAD:
+			curl_easy_setopt(info->easy, CURLOPT_NOBODY, 1l);
+			break;
+		case OPTIONS:
+			curl_easy_setopt(info->easy, CURLOPT_CUSTOMREQUEST, "OPTIONS");
+			break;
+		case GET:
+			break;
+		case PUT:
 			curl_easy_setopt(info->easy, CURLOPT_POSTFIELDS, info->body.c_str());
-			curl_easy_setopt(info->easy, CURLOPT_POSTFIELDSIZE, info->body.size());
+			curl_easy_setopt(info->easy, CURLOPT_POSTFIELDSIZE_LARGE, info->body.size());
+			curl_easy_setopt(info->easy, CURLOPT_CUSTOMREQUEST, "PUT");
+			break;
+		case POST:
+			curl_easy_setopt(info->easy, CURLOPT_POST, 1);
+			curl_easy_setopt(info->easy, CURLOPT_POSTFIELDS, info->body.c_str());
+			curl_easy_setopt(info->easy, CURLOPT_POSTFIELDSIZE_LARGE, info->body.size());
+			break;
+		case DELETE:
+			curl_easy_setopt(info->easy, CURLOPT_POSTFIELDS, info->body.c_str());
+			curl_easy_setopt(info->easy, CURLOPT_POSTFIELDSIZE_LARGE, info->body.size());
+			curl_easy_setopt(info->easy, CURLOPT_CUSTOMREQUEST, "DELETE");
+			break;
+		case PATCH:
+			curl_easy_setopt(info->easy, CURLOPT_POSTFIELDS, info->body.c_str());
+			curl_easy_setopt(info->easy, CURLOPT_POSTFIELDSIZE_LARGE, info->body.size());
+			curl_easy_setopt(info->easy, CURLOPT_CUSTOMREQUEST, "PATCH");
+			break;
+		default:
+			break;
 		}
 
 		curl_easy_setopt(info->easy, CURLOPT_HTTPHEADER, headers_list);
@@ -589,12 +621,65 @@ const logger &url_fetcher::logger() const
 	return p->logger;
 }
 
+void url_fetcher::options(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request)
+{
+	auto info = std::make_shared<network_manager_private::request_info>();
+	info->stream = stream;
+	info->request = std::move(request);
+	info->command = OPTIONS;
+
+	p->loop.post(std::bind(&network_manager_private::process_info, p, info));
+}
+
+void url_fetcher::head(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request)
+{
+	auto info = std::make_shared<network_manager_private::request_info>();
+	info->stream = stream;
+	info->request = std::move(request);
+	info->command = HEAD;
+
+	p->loop.post(std::bind(&network_manager_private::process_info, p, info));
+}
+
 void url_fetcher::get(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request)
 {
 	auto info = std::make_shared<network_manager_private::request_info>();
 	info->stream = stream;
 	info->request = std::move(request);
 	info->command = GET;
+
+	p->loop.post(std::bind(&network_manager_private::process_info, p, info));
+}
+
+void url_fetcher::put(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request, std::string &&body)
+{
+	auto info = std::make_shared<network_manager_private::request_info>();
+	info->stream = stream;
+	info->request = std::move(request);
+	info->command = PUT;
+	info->body = std::move(body);
+
+	p->loop.post(std::bind(&network_manager_private::process_info, p, info));
+}
+
+void url_fetcher::del(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request, std::string &&body)
+{
+	auto info = std::make_shared<network_manager_private::request_info>();
+	info->stream = stream;
+	info->request = std::move(request);
+	info->command = DELETE;
+	info->body = std::move(body);
+
+	p->loop.post(std::bind(&network_manager_private::process_info, p, info));
+}
+
+void url_fetcher::patch(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request, std::string &&body)
+{
+	auto info = std::make_shared<network_manager_private::request_info>();
+	info->stream = stream;
+	info->request = std::move(request);
+	info->command = PATCH;
+	info->body = std::move(body);
 
 	p->loop.post(std::bind(&network_manager_private::process_info, p, info));
 }

--- a/swarm/urlfetcher/url_fetcher.hpp
+++ b/swarm/urlfetcher/url_fetcher.hpp
@@ -154,6 +154,32 @@ public:
 	 */
 	void get(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request);
 	/*!
+	 * \brief Make HEAD HTTP request to server by \a request. Result will be send to \a stream.
+	 *
+	 * This method is asynchronious, so any information such as received headers/data will
+	 * invoke appropriate methods of \a stream.
+	 *
+	 * This method is thread safe.
+	 *
+	 * Shared pointer to \a stream will be destroyed once the request is finished.
+	 *
+	 * \sa post
+	 */
+	void head(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request);
+	/*!
+	 * \brief Make OPTIONS HTTP request to server by \a request. Result will be send to \a stream.
+	 *
+	 * This method is asynchronious, so any information such as received headers/data will
+	 * invoke appropriate methods of \a stream.
+	 *
+	 * This method is thread safe.
+	 *
+	 * Shared pointer to \a stream will be destroyed once the request is finished.
+	 *
+	 * \sa post
+	 */
+	void options(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request);
+	/*!
 	 * \brief Make POST HTTP request to server by \a request with \a body. Result will be send to \a stream.
 	 *
 	 * This method is asynchronious, so any information such as received headers/data will
@@ -166,6 +192,45 @@ public:
 	 * \sa get
 	 */
 	void post(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request, std::string &&body);
+	/*!
+	 * \brief Make PUT HTTP request to server by \a request with \a body. Result will be send to \a stream.
+	 *
+	 * This method is asynchronious, so any information such as received headers/data will
+	 * invoke appropriate methods of \a stream.
+	 *
+	 * This method is thread safe.
+	 *
+	 * Shared pointer to \a stream will be destroyed once the request is finished.
+	 *
+	 * \sa get
+	 */
+	void put(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request, std::string &&body);
+	/*!
+	 * \brief Make DELETE HTTP request to server by \a request with \a body. Result will be send to \a stream.
+	 *
+	 * This method is asynchronious, so any information such as received headers/data will
+	 * invoke appropriate methods of \a stream.
+	 *
+	 * This method is thread safe.
+	 *
+	 * Shared pointer to \a stream will be destroyed once the request is finished.
+	 *
+	 * \sa get
+	 */
+	void del(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request, std::string &&body);
+	/*!
+	 * \brief Make PATCH HTTP request to server by \a request with \a body. Result will be send to \a stream.
+	 *
+	 * This method is asynchronious, so any information such as received headers/data will
+	 * invoke appropriate methods of \a stream.
+	 *
+	 * This method is thread safe.
+	 *
+	 * Shared pointer to \a stream will be destroyed once the request is finished.
+	 *
+	 * \sa get
+	 */
+	void patch(const std::shared_ptr<base_stream> &stream, url_fetcher::request &&request, std::string &&body);
 
 private:
 	url_fetcher(const url_fetcher &other) = delete;


### PR DESCRIPTION
Please review this patch that adds the methods
```
urlfetcher::head
urlfetcher::options
urlfetcher::put
urlfetcher::del
urlfetcher::patch
```
that allow for the corresponding HTTP request.