### PR TITLE
boost::optional does not allow to hold a reference to what it returns…

### DIFF
--- a/swarm/http_response.cpp
+++ b/swarm/http_response.cpp
@@ -201,10 +201,9 @@ std::vector<boost::asio::const_buffer> http_response::to_buffers() const {
 	buffers.push_back(boost::asio::buffer(m_data->code_str));
 	buffers.push_back(to_buffer(" "));
 
-	if (auto reason_phrase = m_data->reason) {
-		buffers.push_back(boost::asio::buffer(*reason_phrase));
-	}
-	else {
+	if (m_data->reason) {
+		buffers.push_back(boost::asio::buffer(m_data->reason.get()));
+	} else {
 		const char* reason = default_reason(code());
 		size_t reason_len = strlen(reason);
 		buffers.push_back(boost::asio::buffer(reason, reason_len));

--- a/thevoid/connection.cpp
+++ b/thevoid/connection.cpp
@@ -149,7 +149,7 @@ std::string headers_to_string(
 	bool first_header = true;
 	for (const auto& log_header: log_headers) {
 		if (headers.has(log_header)) {
-			const auto& header_value = *headers.get(log_header);
+			std::string header_value = *headers.get(log_header);
 
 			if (!first_header) {
 				output++ = ','; output++ = ' ';


### PR DESCRIPTION
…, data must be copied. This patch fixes invalid memory access.